### PR TITLE
Reject empty Gate and Proof discovery

### DIFF
--- a/fixtures/empty-discovery/redproof.config.ts
+++ b/fixtures/empty-discovery/redproof.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'redproof';
+
+export default defineConfig({
+  root: '.',
+  gatesRoot: 'gates/**/*.ts',
+});

--- a/packages/redproof/src/runtime/discovery.ts
+++ b/packages/redproof/src/runtime/discovery.ts
@@ -46,6 +46,12 @@ export async function loadProject(configPath: string): Promise<LoadedProject> {
     }
   }
 
+  if (files.size === 0) {
+    throw new Error(
+      `No Gate modules found under ${projectRoot} for ${config.gatesRoot.map(pattern => JSON.stringify(pattern)).join(', ')}.`,
+    );
+  }
+
   const modules: LoadedGateModule[] = [];
   for (const file of [...files].sort()) {
     modules.push(await loadGateModule(file));

--- a/packages/redproof/src/runtime/shell/project-runner.ts
+++ b/packages/redproof/src/runtime/shell/project-runner.ts
@@ -121,6 +121,14 @@ export type ProveProjectRun = {
 
 export async function proveProject(configPath: string): Promise<ProveProjectRun> {
   const project = await loadProject(configPath);
+  const proofCount = project.modules.reduce(
+    (count, module) => count + (module.proofs?.proofs.length ?? 0),
+    0,
+  );
+  if (proofCount === 0) {
+    throw new Error('No Proofs found. Export a non-empty `proofs` suite from at least one Gate module.');
+  }
+
   const policy = executionPolicy(project.execution);
   const outcomes = policy.mode === 'copies'
     ? await proveInCopies(project, policy.maxAtOnce)

--- a/tests/execution.test.ts
+++ b/tests/execution.test.ts
@@ -85,3 +85,17 @@ test('copies mode rejects a proof when UndoMutation leaves the Gate copy stale',
 
   await assert.rejects(stat(resolve('fixtures/execution-copies-stale/.redproof')));
 });
+
+test('project commands reject a config that discovers no Gates', async () => {
+  const config = configOf('empty-discovery');
+
+  await assert.rejects(checkProject(config), /No Gate modules found/);
+  await assert.rejects(proveProject(config), /No Gate modules found/);
+});
+
+test('prove rejects a project with Gates but no Proofs', async () => {
+  await assert.rejects(
+    proveProject(configOf('pass-single')),
+    /No Proofs found/,
+  );
+});


### PR DESCRIPTION
## Problem

A typo in gatesRoot currently makes check and prove exit successfully with zero work. Likewise, prove exits successfully when discovered Gate modules export no Proofs. Both cases can silently disable CI verification.

## Fix

- Fail discovery when the configured glob matches no Gate modules.
- Fail a project prove run when the discovered suites contain zero Proofs.
- Add regression coverage for empty discovery and check-only Gate modules.

## Verification

- npm run typecheck
- npm run build
- npm run test:runtime (27/27 passing)