### PR TITLE
Fix documentation links in the npm README

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,20 +220,20 @@ REFUSE   the Check could not decide safely
 
 You do not need to build every Gate yourself.
 
-- **[`@redproof/testing`](docs/adapters.md#testing)** — test suites, skipped tests, TODO tests; supports Jest-compatible JSON and JUnit XML
-- **[`@redproof/eslint`](docs/adapters.md#eslint)** — selected ESLint rules as Redproof Rules
-- **[`@redproof/dependency-cruiser`](docs/adapters.md#dependency-cruiser)** — architecture and dependency boundaries
-- **[`@redproof/stryker`](docs/adapters.md#stryker)** — mutation detection and mutation-score policies
+- **[`@redproof/testing`](https://github.com/schalermthai/redproof/blob/main/docs/adapters.md#testing)** — test suites, skipped tests, TODO tests; supports Jest-compatible JSON and JUnit XML
+- **[`@redproof/eslint`](https://github.com/schalermthai/redproof/blob/main/docs/adapters.md#eslint)** — selected ESLint rules as Redproof Rules
+- **[`@redproof/dependency-cruiser`](https://github.com/schalermthai/redproof/blob/main/docs/adapters.md#dependency-cruiser)** — architecture and dependency boundaries
+- **[`@redproof/stryker`](https://github.com/schalermthai/redproof/blob/main/docs/adapters.md#stryker)** — mutation detection and mutation-score policies
 
-See **[Built-in integrations](docs/adapters.md)** for examples.
+See **[Built-in integrations](https://github.com/schalermthai/redproof/blob/main/docs/adapters.md)** for examples.
 
 ## Build your own
 
 Redproof is designed to be composed when an existing integration does not fit your guardrail.
 
-See **[Composing Redproof](docs/composition.md)** to create your own Gates, Rules, Checks, Proofs, Mutations, and Adapters.
+See **[Composing Redproof](https://github.com/schalermthai/redproof/blob/main/docs/composition.md)** to create your own Gates, Rules, Checks, Proofs, Mutations, and Adapters.
 
-For execution isolation, machine-readable reports, VS Code, and other workflows, see **[Tutorials](docs/tutorials/README.md)**.
+For execution isolation, machine-readable reports, VS Code, and other workflows, see **[Tutorials](https://github.com/schalermthai/redproof/blob/main/docs/tutorials/README.md)**.
 
 ## Install
 
@@ -299,9 +299,9 @@ npm run redproof:describe -- gates/no-todo.ts
 
 ## Learn more
 
-- **[Built-in integrations](docs/adapters.md)**
-- **[Composing Redproof](docs/composition.md)**
-- **[Tutorials](docs/tutorials/README.md)**
+- **[Built-in integrations](https://github.com/schalermthai/redproof/blob/main/docs/adapters.md)**
+- **[Composing Redproof](https://github.com/schalermthai/redproof/blob/main/docs/composition.md)**
+- **[Tutorials](https://github.com/schalermthai/redproof/blob/main/docs/tutorials/README.md)**
 
 ## License
 

--- a/scripts/verify-package.ts
+++ b/scripts/verify-package.ts
@@ -82,6 +82,9 @@ try {
     const leaked = entries.filter(entry => FORBIDDEN_IN_TARBALL.some(bad => entry.startsWith(bad)));
     const hasLicense = entries.includes('package/LICENSE');
     const hasReadme = entries.includes('package/README.md');
+    const readme = hasReadme
+      ? run('tar', ['-xzOf', join(packDir, file), 'package/README.md'], workdir)
+      : '';
 
     const manifest = JSON.parse(
       run('tar', ['-xzOf', join(packDir, file), 'package/package.json'], workdir),
@@ -91,6 +94,12 @@ try {
     report(leaked.length === 0, `${pkg.name}: ships no source`, leaked.join(', '));
     report(hasLicense, `${pkg.name}: ships LICENSE`);
     report(hasReadme, `${pkg.name}: ships README.md`);
+    if (pkg.name === 'redproof' && hasReadme) {
+      report(
+        !/\]\((?:\.\/)?docs\//.test(readme),
+        `${pkg.name}: README has no links to unshipped relative docs`,
+      );
+    }
     report(
       manifest.types === './dist/index.d.ts',
       `${pkg.name}: declares a top-level types field`,


### PR DESCRIPTION
## Problem

The published redproof README links to relative docs paths, but the npm artifact ships only dist and schema. Installed-package documentation links therefore point to files that are not present.

## Fix

Use absolute GitHub URLs for documentation links and make package verification reject links to unshipped relative docs.

## Verification

- npm run build
- npm run verify:package
- All five tarballs packed, installed, imported, type-checked, and passed consumer CLI checks.