### PR TITLE
Name changed paths in workspace restoration errors

### DIFF
--- a/packages/redproof/src/runtime/core/restoration.ts
+++ b/packages/redproof/src/runtime/core/restoration.ts
@@ -1,11 +1,36 @@
 export type TreeStamp = {
   readonly digest: string;
   readonly entries: number;
+  readonly fingerprints?: Readonly<Record<string, string>>;
 };
 
 export type Freshness =
   | { readonly kind: 'fresh' }
   | { readonly kind: 'stale'; readonly why: string };
+
+const MAX_CHANGED_PATHS = 8;
+
+function changedPaths(baseline: TreeStamp, current: TreeStamp): string {
+  if (!baseline.fingerprints || !current.fingerprints) return '';
+
+  const paths = [...new Set([
+    ...Object.keys(baseline.fingerprints),
+    ...Object.keys(current.fingerprints),
+  ])].sort();
+  const changes: string[] = [];
+
+  for (const path of paths) {
+    if (!Object.hasOwn(baseline.fingerprints, path)) changes.push(`added ${path}`);
+    else if (!Object.hasOwn(current.fingerprints, path)) changes.push(`removed ${path}`);
+    else if (baseline.fingerprints[path] !== current.fingerprints[path]) changes.push(`modified ${path}`);
+  }
+
+  const shown = changes.slice(0, MAX_CHANGED_PATHS);
+  const omitted = changes.length - shown.length;
+  return shown.length === 0
+    ? ''
+    : `; changed paths: ${shown.join(', ')}${omitted > 0 ? `, and ${omitted} more` : ''}`;
+}
 
 /** Pure comparison of a workspace baseline with its current tree stamp. */
 export function assessFreshness(baseline: TreeStamp, current: TreeStamp): Freshness {
@@ -15,6 +40,7 @@ export function assessFreshness(baseline: TreeStamp, current: TreeStamp): Freshn
 
   return {
     kind: 'stale',
-    why: `workspace changed from ${baseline.digest.slice(0, 12)} to ${current.digest.slice(0, 12)}`,
+    why: `workspace changed from ${baseline.digest.slice(0, 12)} to ${current.digest.slice(0, 12)}`
+      + changedPaths(baseline, current),
   };
 }

--- a/packages/redproof/src/runtime/workspace.ts
+++ b/packages/redproof/src/runtime/workspace.ts
@@ -52,7 +52,18 @@ async function copyEntry(source: string, target: string): Promise<void> {
   }
 }
 
-async function collectStamp(root: string, current: string, hash: ReturnType<typeof createHash>): Promise<number> {
+function fingerprint(...parts: (string | Buffer)[]): string {
+  const hash = createHash('sha256');
+  for (const part of parts) hash.update(part);
+  return hash.digest('hex');
+}
+
+async function collectStamp(
+  root: string,
+  current: string,
+  hash: ReturnType<typeof createHash>,
+  fingerprints: Record<string, string>,
+): Promise<number> {
   const entries = await readdir(current, { withFileTypes: true });
   let count = 0;
 
@@ -65,22 +76,29 @@ async function collectStamp(root: string, current: string, hash: ReturnType<type
     const mode = info.mode & 0o777;
 
     if (info.isDirectory()) {
-      hash.update(`D\0${rel}\0${mode}\0`);
+      const metadata = `D\0${rel}\0${mode}\0`;
+      hash.update(metadata);
+      fingerprints[rel] = fingerprint(metadata);
       count += 1;
-      count += await collectStamp(root, absolute, hash);
+      count += await collectStamp(root, absolute, hash, fingerprints);
       continue;
     }
 
     if (info.isSymbolicLink()) {
-      hash.update(`L\0${rel}\0${mode}\0${await readlink(absolute)}\0`);
+      const metadata = `L\0${rel}\0${mode}\0${await readlink(absolute)}\0`;
+      hash.update(metadata);
+      fingerprints[rel] = fingerprint(metadata);
       count += 1;
       continue;
     }
 
     if (info.isFile()) {
-      hash.update(`F\0${rel}\0${mode}\0`);
-      hash.update(await readFile(absolute));
+      const metadata = `F\0${rel}\0${mode}\0`;
+      const contents = await readFile(absolute);
+      hash.update(metadata);
+      hash.update(contents);
       hash.update('\0');
+      fingerprints[rel] = fingerprint(metadata, contents, '\0');
       count += 1;
     }
   }
@@ -91,8 +109,9 @@ async function collectStamp(root: string, current: string, hash: ReturnType<type
 export async function stampTree(root: string): Promise<TreeStamp> {
   const absolute = resolve(root);
   const hash = createHash('sha256');
-  const entries = await collectStamp(absolute, absolute, hash);
-  return { digest: hash.digest('hex'), entries };
+  const fingerprints: Record<string, string> = Object.create(null);
+  const entries = await collectStamp(absolute, absolute, hash, fingerprints);
+  return { digest: hash.digest('hex'), entries, fingerprints };
 }
 
 export async function verifyTree(root: string, baseline: TreeStamp): Promise<Freshness> {

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -112,6 +112,26 @@ test('freshness comparison is pure and checks both digest and entry count', () =
   );
 });
 
+test('freshness diagnostics identify added, removed, and modified paths', () => {
+  const freshness = assessFreshness(
+    {
+      digest: 'before',
+      entries: 2,
+      fingerprints: { 'removed.ts': 'old', 'modified.ts': 'old' },
+    },
+    {
+      digest: 'after',
+      entries: 2,
+      fingerprints: { 'added.ts': 'new', 'modified.ts': 'new' },
+    },
+  );
+
+  assert.deepEqual(freshness, {
+    kind: 'stale',
+    why: 'workspace changed from before to after; changed paths: added added.ts, modified modified.ts, removed removed.ts',
+  });
+});
+
 test('restoration failure replaces proof success and prevents copy reuse', () => {
   const result = pass(scan);
   const completed: ProofOutcome = {

--- a/tests/execution.test.ts
+++ b/tests/execution.test.ts
@@ -80,6 +80,7 @@ test('copies mode rejects a proof when UndoMutation leaves the Gate copy stale',
   assert.equal(outcome.status, 'error');
   if (outcome.status !== 'error') throw new Error('expected infrastructure error');
   assert.equal(outcome.error.code, 'workspace-not-restored');
+  assert.match(outcome.error.detail ?? '', /modified src\/state\.txt/);
   assert.equal(outcome.result?.verdict, 'fail');
   assert.equal(await readFile(source, 'utf8'), before, 'the original workspace must stay untouched');
 


### PR DESCRIPTION
## Problem

When UndoMutation leaves a copied workspace stale, the error only shows before and after digest prefixes. Users cannot tell which files were added, removed, or modified.

## Fix

Record per-entry fingerprints in TreeStamp and append a bounded, deterministic changed-path summary to stale-workspace diagnostics.

## Verification

- Added pure coverage for added, modified, and removed paths.
- Added integration coverage for the leaked src/state.txt fixture.
- npm run typecheck
- npm run build
- npm run test:core (11/11 passing)
- npm run test:runtime (25/25 passing)