### PR TITLE
Keep Check logs out of machine reporter stdout

### DIFF
--- a/fixtures/logging-check/gates/logging.ts
+++ b/fixtures/logging-check/gates/logging.ts
@@ -1,0 +1,20 @@
+import { counting, defineAdapter, defineGate, pass } from 'redproof';
+
+const rule = { id: 'logging/passes', description: 'passes after logging' } as const;
+
+export default defineGate({
+  id: 'logging',
+  adapter: defineAdapter({
+    kind: 'fixture',
+    rules: { rule },
+    check: {
+      description: 'log while checking',
+      counting: counting.supported,
+      async run() {
+        console.log('message from Check');
+        const now = new Date().toISOString();
+        return pass({ source: 'logging', startedAt: now, finishedAt: now, inspected: 1 });
+      },
+    },
+  }),
+});

--- a/fixtures/logging-check/package.json
+++ b/fixtures/logging-check/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "logging-check",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "redproof": "file:../../packages/redproof"
+  }
+}

--- a/fixtures/logging-check/redproof.config.ts
+++ b/fixtures/logging-check/redproof.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'redproof';
+
+export default defineConfig({
+  root: '.',
+  gatesRoot: 'gates/**/*.ts',
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,6 +86,11 @@
         "redproof": "file:../../packages/redproof"
       }
     },
+    "fixtures/logging-check": {
+      "dependencies": {
+        "redproof": "file:../../packages/redproof"
+      }
+    },
     "fixtures/mixed": {
       "dependencies": {
         "redproof": "file:../../packages/redproof"
@@ -3609,6 +3614,10 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "license": "MIT"
+    },
+    "node_modules/logging-check": {
+      "resolved": "fixtures/logging-check",
+      "link": true
     },
     "node_modules/lru-cache": {
       "version": "11.5.2",

--- a/packages/redproof/src/runtime/shell/worker-process.ts
+++ b/packages/redproof/src/runtime/shell/worker-process.ts
@@ -31,8 +31,10 @@ export function runGateWorker(job: GateWorkerJob): Promise<GateWorkerResult> {
   return new Promise((resolve, reject) => {
     const child = fork(gateWorkerFile, [], {
       execArgv: ['--disable-warning=ExperimentalWarning', '--experimental-strip-types'],
-      stdio: ['ignore', 'inherit', 'inherit', 'ipc'],
+      stdio: ['ignore', 'pipe', 'inherit', 'ipc'],
     });
+
+    child.stdout?.pipe(process.stderr);
 
     let settled = false;
 

--- a/tests/reporter/cli.test.ts
+++ b/tests/reporter/cli.test.ts
@@ -47,6 +47,24 @@ test('CLI writes JSON output relative to the project root', async () => {
   await rm(resolve('fixtures/pass-single/.redproof'), { recursive: true, force: true });
 });
 
+test('CLI keeps Check logs out of machine-readable stdout', () => {
+  const result = spawnSync(process.execPath, [
+    '--disable-warning=ExperimentalWarning',
+    '--experimental-strip-types',
+    'packages/redproof/src/cli.ts',
+    'check',
+    '--config',
+    'fixtures/logging-check/redproof.config.ts',
+    '--reporter=json',
+  ], { cwd: resolve('.'), encoding: 'utf8' });
+
+  assert.equal(result.status, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.status, 'passed');
+  assert.doesNotMatch(result.stdout, /message from Check/);
+  assert.match(result.stderr, /message from Check/);
+});
+
 test('CLI describe can target one discovered Gate file', () => {
   const result = spawnSync(process.execPath, [
     '--disable-warning=ExperimentalWarning',


### PR DESCRIPTION
## Problem

When a custom Check writes to stdout, the inherited Gate-worker stream prefixes JSON reporter output. The command exits successfully but stdout is not valid JSON.

## Fix

Pipe Gate-worker stdout into coordinator stderr, reserving coordinator stdout for reporter output.

## Verification

- Added a logging Check fixture.
- Regression parses JSON stdout and confirms the Check message appears only on stderr.
- npm run typecheck
- npm run build
- npm run test:runtime (26/26 passing)