### PR TITLE
Require RED proofs to demonstrate causality

### DIFF
--- a/packages/redproof/src/runtime/shell/gate-runner.ts
+++ b/packages/redproof/src/runtime/shell/gate-runner.ts
@@ -2,7 +2,7 @@ import type { Adapter } from '../../domain/adapter.ts';
 import type { CheckResult } from '../../domain/check.ts';
 import type { Gate } from '../../domain/gate.ts';
 import type { MutationPlan, UndoMutation } from '../../domain/mutation.ts';
-import type { Proof } from '../../domain/proof.ts';
+import type { Proof, RedProof } from '../../domain/proof.ts';
 import type { RuleRef } from '../../domain/rule.ts';
 import { evaluateProof, proofSucceeded } from '../core/proof-evaluation.ts';
 import type {
@@ -41,6 +41,10 @@ function errorDetail(error: unknown): string {
   return error instanceof Error ? error.stack ?? error.message : String(error);
 }
 
+function targetIsBreached(proof: RedProof, result: CheckResult): boolean {
+  return result.verdict === 'fail' && result.breaches.some(item => item.rule === proof.target);
+}
+
 function proofError(
   gate: Gate<any>,
   proof: Proof,
@@ -63,6 +67,33 @@ function proofError(
 
 /** Imperative shell: apply mutation, invoke Check, restore mutation. Proof meaning is delegated to the pure core. */
 export async function runProof(gate: Gate<any>, proof: Proof, root: string): Promise<ProofOutcome> {
+  if (proof.expected === 'red') {
+    let baseline: CheckResult;
+    try {
+      baseline = await runGate(gate, root);
+    } catch (error) {
+      return proofError(
+        gate,
+        proof,
+        'check-threw',
+        'The baseline Check threw instead of returning a CheckResult.',
+        error,
+      );
+    }
+
+    if (targetIsBreached(proof, baseline)) {
+      return {
+        status: 'completed',
+        gate: gate.id,
+        proof: proof.name,
+        expected: proof.expected,
+        ok: false,
+        result: baseline,
+        workerPid: process.pid,
+      };
+    }
+  }
+
   let undos: UndoMutation[];
   try {
     undos = await applyMutations(root, proof.mutate);

--- a/tests/proof.test.ts
+++ b/tests/proof.test.ts
@@ -57,3 +57,45 @@ test('RED proof does not pass when the Gate fails for another Rule', async () =>
   assert.equal(outcome.result.verdict, 'fail');
   assert.equal(outcome.ok, false);
 });
+
+test('RED proof does not pass when its target was already breached before mutation', async () => {
+  let mutationApplied = false;
+  const alreadyRedGate = defineGate({
+    id: 'already-red',
+    adapter: defineAdapter({
+      kind: 'test',
+      rules: { r1: R1 },
+      check: {
+        description: 'always breach R1',
+        counting: counting.supported,
+        async run() {
+          return fail(scan, [
+            breach(R1.id, {
+              code: 'r1',
+              message: 'R1 was already breached.',
+              location: null,
+            }),
+          ]);
+        },
+      },
+    }),
+  });
+
+  const outcome = await runProof(
+    alreadyRedGate,
+    proof.red(R1, 'prove R1 causally', {
+      description: 'irrelevant mutation',
+      async apply() {
+        mutationApplied = true;
+        return async () => {};
+      },
+    }),
+    process.cwd(),
+  );
+
+  assert.equal(outcome.status, 'completed');
+  if (outcome.status !== 'completed') throw new Error('expected completed proof');
+  assert.equal(outcome.result.verdict, 'fail');
+  assert.equal(outcome.ok, false);
+  assert.equal(mutationApplied, false);
+});


### PR DESCRIPTION
## Problem

A RED proof is accepted when its target Rule was already breached before the mutation. An irrelevant mutation can therefore be reported as proved.

## Fix

Run the Check against the unmutated baseline before each RED mutation. If the target Rule is already breached, reject the proof and do not apply the mutation.

## Verification

- Added a regression proving an always-red target rejects an irrelevant mutation.
- npm run typecheck
- npm run build
- npm run test:runtime (26/26 passing)
- npm test (90/90 passing)