### PR TITLE
Add CLI help, version, and config validation

### DIFF
--- a/packages/redproof/src/cli.ts
+++ b/packages/redproof/src/cli.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, isAbsolute, resolve } from 'node:path';
 import { describeProject } from './runtime/describe.ts';
 import {
@@ -14,10 +14,41 @@ import { checkProject, proveProject } from './runtime/run.ts';
 
 const args = process.argv.slice(2);
 const command = args[0] ?? 'check';
-const configIndex = args.indexOf('--config');
-const configPath = resolve(configIndex >= 0 ? args[configIndex + 1]! : 'redproof.config.ts');
 const color = process.stdout.isTTY && !args.includes('--no-color');
 const verbose = args.includes('--verbose');
+
+const HELP = `Usage: redproof [command] [options]
+
+Commands:
+  check       Run all discovered Gates (default)
+  prove       Run all discovered Proofs
+  describe    Describe discovered Gates
+
+Options:
+  --config <path>       Path to redproof.config.ts
+  --reporter <reporter> Select an output reporter
+  --outputFile <path>   Write reporter output to a file
+  --no-color            Disable colored output
+  --verbose             Include passing details
+  -h, --help            Show this help
+  -v, --version         Show the installed version`;
+
+function configArg(argv: readonly string[]): string | undefined {
+  const inline = argv.find(arg => arg.startsWith('--config='));
+  if (inline !== undefined) return inline.slice('--config='.length) || undefined;
+
+  const index = argv.indexOf('--config');
+  if (index < 0) return 'redproof.config.ts';
+  const value = argv[index + 1];
+  return value && !value.startsWith('-') ? value : undefined;
+}
+
+async function packageVersion(): Promise<string> {
+  const manifest = JSON.parse(
+    await readFile(new URL('../package.json', import.meta.url), 'utf8'),
+  ) as { version: string };
+  return manifest.version;
+}
 
 function positionalArgs(argv: readonly string[]): readonly string[] {
   const positionals: string[] = [];
@@ -46,32 +77,58 @@ async function emit(spec: ReporterSpec, text: string, projectRoot: string): Prom
   await writeFile(file, text.endsWith('\n') ? text : `${text}\n`, 'utf8');
 }
 
-if (command === 'describe') {
-  const [gateFile] = positionalArgs(args);
-  const run = await describeProject(configPath, gateFile);
-  console.log(run.descriptions.map(formatGateDescription).join('\n\n'));
-} else if (command === 'prove') {
-  const specs = parseReporterArgs(args);
-  for (const spec of specs) {
-    if (spec.name !== 'default' && spec.name !== 'json') {
-      throw new Error(`Reporter ${spec.name} does not support the prove command.`);
-    }
+async function main(): Promise<number> {
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(HELP);
+    return 0;
   }
 
-  const run = await proveProject(configPath);
-  for (const spec of specs) {
-    await emit(spec, renderProveReporter(spec.name as ProveReporterName, run), run.project.root);
+  if (args.includes('--version') || args.includes('-v')) {
+    console.log(await packageVersion());
+    return 0;
   }
-  process.exitCode = run.exitCode;
-} else if (command === 'check') {
-  const specs = parseReporterArgs(args);
-  const run = await checkProject(configPath);
-  for (const spec of specs) {
-    const output = await renderCheckReporter(spec.name, run, { color, verbose });
-    await emit(spec, output, run.project.root);
+
+  const configValue = configArg(args);
+  if (configValue === undefined) {
+    console.error('Option --config requires a path.');
+    return 2;
   }
-  process.exitCode = run.exitCode;
-} else {
+  const configPath = resolve(configValue);
+
+  if (command === 'describe') {
+    const [gateFile] = positionalArgs(args);
+    const run = await describeProject(configPath, gateFile);
+    console.log(run.descriptions.map(formatGateDescription).join('\n\n'));
+    return 0;
+  }
+
+  if (command === 'prove') {
+    const specs = parseReporterArgs(args);
+    for (const spec of specs) {
+      if (spec.name !== 'default' && spec.name !== 'json') {
+        throw new Error(`Reporter ${spec.name} does not support the prove command.`);
+      }
+    }
+
+    const run = await proveProject(configPath);
+    for (const spec of specs) {
+      await emit(spec, renderProveReporter(spec.name as ProveReporterName, run), run.project.root);
+    }
+    return run.exitCode;
+  }
+
+  if (command === 'check') {
+    const specs = parseReporterArgs(args);
+    const run = await checkProject(configPath);
+    for (const spec of specs) {
+      const output = await renderCheckReporter(spec.name, run, { color, verbose });
+      await emit(spec, output, run.project.root);
+    }
+    return run.exitCode;
+  }
+
   console.error(`Unknown command: ${command}`);
-  process.exitCode = 2;
+  return 2;
 }
+
+process.exitCode = await main();

--- a/tests/reporter/cli.test.ts
+++ b/tests/reporter/cli.test.ts
@@ -25,6 +25,48 @@ test('reporter CLI parser rejects two reporters writing to stdout', () => {
   );
 });
 
+test('CLI prints help without loading a project', () => {
+  const result = spawnSync(process.execPath, [
+    '--disable-warning=ExperimentalWarning',
+    '--experimental-strip-types',
+    'packages/redproof/src/cli.ts',
+    '--help',
+  ], { cwd: resolve('.'), encoding: 'utf8' });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /^Usage: redproof/m);
+  assert.match(result.stdout, /--config <path>/);
+});
+
+test('CLI prints its package version', async () => {
+  const result = spawnSync(process.execPath, [
+    '--disable-warning=ExperimentalWarning',
+    '--experimental-strip-types',
+    'packages/redproof/src/cli.ts',
+    '--version',
+  ], { cwd: resolve('.'), encoding: 'utf8' });
+
+  assert.equal(result.status, 0, result.stderr);
+  const manifest = JSON.parse(
+    await readFile(resolve('packages/redproof/package.json'), 'utf8'),
+  ) as { version: string };
+  assert.equal(result.stdout.trim(), manifest.version);
+});
+
+test('CLI reports a missing config value without an internal stack trace', () => {
+  const result = spawnSync(process.execPath, [
+    '--disable-warning=ExperimentalWarning',
+    '--experimental-strip-types',
+    'packages/redproof/src/cli.ts',
+    'check',
+    '--config',
+  ], { cwd: resolve('.'), encoding: 'utf8' });
+
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /^Option --config requires a path\.\n$/);
+  assert.doesNotMatch(result.stderr, /node:path|at main|ERR_/);
+});
+
 test('CLI writes JSON output relative to the project root', async () => {
   const output = resolve('fixtures/pass-single/.redproof/reporter-test.json');
   await rm(output, { force: true });


### PR DESCRIPTION
## Problem

--help and --version are treated as unknown commands. Passing --config without a value reaches node:path and emits an internal stack trace.

## Fix

- Add standard help and version output.
- Validate the config option before path resolution.
- Return exit code 2 with a concise usage diagnostic for a missing value.

## Verification

- npm run typecheck
- npm run build
- npm run test:runtime (28/28 passing)
- npm run test:reporter (23/23 passing)