### PR TITLE
Add reusable command Checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,24 @@ See **[Built-in integrations](https://github.com/schalermthai/redproof/blob/main
 
 Redproof is designed to be composed when an existing integration does not fit your guardrail.
 
+For a guardrail exposed as an executable, use the official `redproof/command` Check:
+
+```ts
+import { command } from 'redproof/command';
+
+const gate = defineGate({
+  id: 'docs',
+  rules,
+  check: command({
+    rule: rules.docs,
+    command: 'npm',
+    args: ['run', 'lint:docs'],
+  }),
+});
+```
+
+Completed failure exits breach the selected Rule. Missing executables, timeouts, signals, output overflow, and explicitly unclassified exits produce **REFUSE**.
+
 See **[Composing Redproof](https://github.com/schalermthai/redproof/blob/main/docs/composition.md)** to create your own Gates, Rules, Checks, Proofs, Mutations, and Adapters.
 
 For execution isolation, machine-readable reports, VS Code, and other workflows, see **[Tutorials](https://github.com/schalermthai/redproof/blob/main/docs/tutorials/README.md)**.

--- a/docs/composition.md
+++ b/docs/composition.md
@@ -352,6 +352,45 @@ const check = defineCheck(rules, {
 
 This keeps the set of Rules the Check may breach type-safe.
 
+### Command Checks
+
+Use `redproof/command` when an existing guardrail is exposed as an executable and its process status is the trustworthy policy result:
+
+```ts
+import { command } from 'redproof/command';
+
+const check = command({
+  rule: rules.docs,
+  command: 'npm',
+  args: ['run', 'lint:docs'],
+  timeoutMs: 60_000,
+});
+```
+
+By default, exit code `0` produces PASS and any other ordinary exit code breaches `rule`. Process infrastructure failures produce REFUSE:
+
+- the executable cannot start
+- the process exceeds `timeoutMs`
+- the process is terminated by a signal
+- combined stdout and stderr exceed `maxOutputBytes` (10 MiB by default)
+- the process returns an exit code not covered by an explicit policy
+
+Use an explicit policy when the tool distinguishes findings from configuration or invocation errors:
+
+```ts
+const check = command({
+  rule: rules.lint,
+  command: 'eslint',
+  args: ['src'],
+  exitCodes: {
+    pass: [0],
+    breach: [1],
+  },
+});
+```
+
+Here, exit code `2` produces REFUSE because it is neither a passing nor a breach exit. Child stdout and stderr are captured for diagnostics and never inherited by reporter stdout. Relative `cwd` values resolve inside the Gate workspace and cannot escape it.
+
 ## Creating an Adapter
 
 Use an Adapter when an external system introduces its own policy model.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "typecheck": "tsc --noEmit",
     "test": "node --disable-warning=ExperimentalWarning --experimental-strip-types --test tests/*.test.ts tests/composition/*.test.ts tests/composition/mutation/*.test.ts tests/adapters/*.test.ts tests/reporter/*.test.ts",
     "test:core": "node --disable-warning=ExperimentalWarning --experimental-strip-types --test tests/core.test.ts",
+    "test:command": "node --disable-warning=ExperimentalWarning --experimental-strip-types --test tests/command.test.ts",
     "test:runtime": "node --disable-warning=ExperimentalWarning --experimental-strip-types --test tests/proof.test.ts tests/execution.test.ts tests/reporter/*.test.ts",
     "fixture:check": "node --disable-warning=ExperimentalWarning --experimental-strip-types packages/redproof/src/cli.ts check --config fixtures/eslint-project/redproof.config.ts",
     "fixture:prove": "node --disable-warning=ExperimentalWarning --experimental-strip-types packages/redproof/src/cli.ts prove --config fixtures/eslint-project/redproof.config.ts",

--- a/packages/redproof/package.json
+++ b/packages/redproof/package.json
@@ -14,6 +14,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./command": {
+      "types": "./dist/command.d.ts",
+      "default": "./dist/command.js"
     }
   },
   "types": "./dist/index.d.ts",

--- a/packages/redproof/src/command.ts
+++ b/packages/redproof/src/command.ts
@@ -1,0 +1,306 @@
+import { spawn } from 'node:child_process';
+import { isAbsolute, relative, resolve, sep } from 'node:path';
+import { breach, counting, result } from './composition/check.ts';
+import type { Check, CheckResult, Scan } from './domain/check.ts';
+import type { Rule, RuleRef } from './domain/rule.ts';
+
+const DEFAULT_MAX_OUTPUT_BYTES = 10 * 1024 * 1024;
+const FORCE_KILL_AFTER_MS = 250;
+
+export type CommandExitCodes = {
+  /** Exit codes that produce PASS. Defaults to `[0]`. */
+  readonly pass?: readonly number[];
+  /** Exit codes that breach the Rule. Defaults to every nonzero code not classified as PASS. */
+  readonly breach?: readonly number[] | 'nonzero';
+};
+
+export type CommandCheckOptions<R extends RuleRef> = {
+  readonly rule: Rule<R>;
+  readonly command: string;
+  readonly args?: readonly string[];
+  readonly label?: string;
+  readonly description?: string;
+  /** Relative to the Gate root and confined inside it. Defaults to the root. */
+  readonly cwd?: string;
+  readonly env?: Readonly<Record<string, string | undefined>>;
+  readonly timeoutMs?: number;
+  /** Combined stdout and stderr capture limit. Defaults to 10 MiB. */
+  readonly maxOutputBytes?: number;
+  readonly exitCodes?: CommandExitCodes;
+};
+
+type CompletedCommand = {
+  readonly kind: 'completed';
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+};
+
+type RefusedCommand = {
+  readonly kind: 'refused';
+  readonly code:
+    | 'command-unavailable'
+    | 'command-timeout'
+    | 'command-signaled'
+    | 'command-output-limit';
+  readonly message: string;
+  readonly detail?: string;
+};
+
+type CommandExecution = CompletedCommand | RefusedCommand;
+
+type NormalizedExitCodes = {
+  readonly pass: ReadonlySet<number>;
+  readonly breach: ReadonlySet<number> | 'nonzero';
+};
+
+function validatePositiveInteger(name: string, value: number | undefined): void {
+  if (value !== undefined && (!Number.isSafeInteger(value) || value <= 0)) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+}
+
+function validateExitCode(name: string, value: number): void {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${name} must contain only non-negative integers.`);
+  }
+}
+
+function normalizeExitCodes(options: CommandExitCodes | undefined): NormalizedExitCodes {
+  const passCodes = options?.pass ?? [0];
+  const breachCodes = options?.breach ?? 'nonzero';
+
+  for (const code of passCodes) validateExitCode('exitCodes.pass', code);
+  if (breachCodes !== 'nonzero') {
+    for (const code of breachCodes) validateExitCode('exitCodes.breach', code);
+  }
+
+  const pass = new Set(passCodes);
+  if (breachCodes !== 'nonzero') {
+    for (const code of breachCodes) {
+      if (pass.has(code)) {
+        throw new Error(`Exit code ${code} cannot produce both PASS and a Breach.`);
+      }
+    }
+  }
+
+  return {
+    pass,
+    breach: breachCodes === 'nonzero' ? breachCodes : new Set(breachCodes),
+  };
+}
+
+function outputDetail(stdout: string, stderr: string, prefix?: string): string | undefined {
+  const sections = [
+    prefix,
+    stdout ? `stdout:\n${stdout}` : undefined,
+    stderr ? `stderr:\n${stderr}` : undefined,
+  ].filter((section): section is string => section !== undefined);
+  return sections.length > 0 ? sections.join('\n\n') : undefined;
+}
+
+function executeCommand(
+  options: CommandCheckOptions<RuleRef>,
+  cwd: string,
+  maxOutputBytes: number,
+): Promise<CommandExecution> {
+  return new Promise(resolveExecution => {
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(options.command, options.args ?? [], {
+        cwd,
+        env: { ...process.env, ...options.env },
+        shell: false,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+    } catch (error) {
+      resolveExecution({
+        kind: 'refused',
+        code: 'command-unavailable',
+        message: `Could not start ${options.label ?? options.command}.`,
+        detail: error instanceof Error ? error.message : String(error),
+      });
+      return;
+    }
+
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    let capturedBytes = 0;
+    let settled = false;
+    let interruption: 'timeout' | 'output-limit' | undefined;
+    let timeout: NodeJS.Timeout | undefined;
+    let forceKill: NodeJS.Timeout | undefined;
+
+    const captured = () => ({
+      stdout: Buffer.concat(stdout).toString('utf8'),
+      stderr: Buffer.concat(stderr).toString('utf8'),
+    });
+
+    const settle = (outcome: CommandExecution): void => {
+      if (settled) return;
+      settled = true;
+      if (timeout) clearTimeout(timeout);
+      if (forceKill) clearTimeout(forceKill);
+      resolveExecution(outcome);
+    };
+
+    const interrupt = (reason: 'timeout' | 'output-limit'): void => {
+      if (interruption) return;
+      interruption = reason;
+      child.kill();
+      forceKill = setTimeout(() => child.kill('SIGKILL'), FORCE_KILL_AFTER_MS);
+      forceKill.unref();
+    };
+
+    const capture = (target: Buffer[], chunk: Buffer | string): void => {
+      if (interruption) return;
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      const remaining = Math.max(0, maxOutputBytes - capturedBytes);
+      if (remaining > 0) target.push(buffer.subarray(0, remaining));
+      capturedBytes += buffer.length;
+      if (capturedBytes > maxOutputBytes) interrupt('output-limit');
+    };
+
+    child.stdout?.on('data', chunk => capture(stdout, chunk));
+    child.stderr?.on('data', chunk => capture(stderr, chunk));
+
+    child.once('error', error => {
+      if (interruption) return;
+      settle({
+        kind: 'refused',
+        code: 'command-unavailable',
+        message: `Could not start ${options.label ?? options.command}.`,
+        detail: error.message,
+      });
+    });
+
+    child.once('close', (code, signal) => {
+      const output = captured();
+      if (interruption === 'timeout') {
+        const detail = outputDetail(output.stdout, output.stderr);
+        settle({
+          kind: 'refused',
+          code: 'command-timeout',
+          message: `${options.label ?? options.command} exceeded its ${options.timeoutMs}ms timeout.`,
+          ...(detail ? { detail } : {}),
+        });
+        return;
+      }
+      if (interruption === 'output-limit') {
+        const detail = outputDetail(output.stdout, output.stderr);
+        settle({
+          kind: 'refused',
+          code: 'command-output-limit',
+          message: `${options.label ?? options.command} exceeded the ${maxOutputBytes}-byte output limit.`,
+          ...(detail ? { detail } : {}),
+        });
+        return;
+      }
+      if (signal) {
+        const detail = outputDetail(output.stdout, output.stderr);
+        settle({
+          kind: 'refused',
+          code: 'command-signaled',
+          message: `${options.label ?? options.command} was terminated by ${signal}.`,
+          ...(detail ? { detail } : {}),
+        });
+        return;
+      }
+
+      settle({
+        kind: 'completed',
+        exitCode: code ?? 1,
+        ...output,
+      });
+    });
+
+    if (options.timeoutMs !== undefined) {
+      timeout = setTimeout(() => interrupt('timeout'), options.timeoutMs);
+      timeout.unref();
+    }
+  });
+}
+
+function isInsideRoot(root: string, candidate: string): boolean {
+  const rel = relative(root, candidate);
+  return rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel);
+}
+
+function scan(source: string, startedAt: string): Scan {
+  return {
+    source,
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    inspected: 1,
+  };
+}
+
+/** Create a Check that maps one executable invocation to PASS, a targeted Breach, or REFUSE. */
+export function command<const R extends RuleRef>(options: CommandCheckOptions<R>): Check<R> {
+  if (!options.command.trim()) throw new Error('command must not be empty.');
+  validatePositiveInteger('timeoutMs', options.timeoutMs);
+  validatePositiveInteger('maxOutputBytes', options.maxOutputBytes);
+
+  const exitCodes = normalizeExitCodes(options.exitCodes);
+  const label = options.label ?? options.command;
+  const maxOutputBytes = options.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES;
+
+  return {
+    description: options.description ?? `run ${label}`,
+    counting: counting.supported,
+
+    async run(ctx): Promise<CheckResult<R>> {
+      const startedAt = new Date().toISOString();
+      const root = resolve(ctx.root);
+      const cwd = resolve(root, options.cwd ?? '.');
+      if (!isInsideRoot(root, cwd)) {
+        return result.refuse(scan(label, startedAt), {
+          code: 'command-cwd-outside-root',
+          message: `The working directory for ${label} resolves outside the Gate root.`,
+          location: null,
+          detail: cwd,
+        });
+      }
+
+      const execution = await executeCommand(options, cwd, maxOutputBytes);
+      const completedScan = scan(label, startedAt);
+      if (execution.kind === 'refused') {
+        return result.refuse(completedScan, {
+          code: execution.code,
+          message: execution.message,
+          location: null,
+          ...(execution.detail ? { detail: execution.detail } : {}),
+        });
+      }
+
+      if (exitCodes.pass.has(execution.exitCode)) return result.pass(completedScan);
+
+      const isBreach = exitCodes.breach === 'nonzero'
+        ? execution.exitCode !== 0
+        : exitCodes.breach.has(execution.exitCode);
+      const detail = outputDetail(
+        execution.stdout,
+        execution.stderr,
+        `exit code: ${execution.exitCode}`,
+      );
+
+      if (isBreach) {
+        return result.fail(completedScan, [
+          breach(options.rule, {
+            code: 'command-exit',
+            message: `${label} exited with code ${execution.exitCode}.`,
+            location: null,
+            ...(detail ? { detail } : {}),
+          }),
+        ]);
+      }
+
+      return result.refuse(completedScan, {
+        code: 'command-exit-unclassified',
+        message: `${label} exited with unclassified code ${execution.exitCode}.`,
+        location: null,
+        ...(detail ? { detail } : {}),
+      });
+    },
+  };
+}

--- a/scripts/verify-package.ts
+++ b/scripts/verify-package.ts
@@ -88,7 +88,11 @@ try {
 
     const manifest = JSON.parse(
       run('tar', ['-xzOf', join(packDir, file), 'package/package.json'], workdir),
-    ) as { types?: string; engines?: { node?: string } };
+    ) as {
+      types?: string;
+      engines?: { node?: string };
+      exports?: Record<string, { types?: string; default?: string }>;
+    };
 
     report(hasDist, `${pkg.name}: ships dist/`);
     report(leaked.length === 0, `${pkg.name}: ships no source`, leaked.join(', '));
@@ -110,6 +114,13 @@ try {
       `${pkg.name}: requires node ${REQUIRED_NODE}`,
       manifest.engines?.node ?? '(missing)',
     );
+    if (pkg.name === 'redproof') {
+      report(
+        manifest.exports?.['./command']?.types === './dist/command.d.ts'
+          && manifest.exports?.['./command']?.default === './dist/command.js',
+        'redproof: exports the command subpath with runtime and types',
+      );
+    }
   }
 
   console.log('\n3. Install the tarballs into a clean project');
@@ -138,6 +149,14 @@ try {
     const result = tryRun('node', ['probe.mjs'], consumer);
     report(result.ok, `${pkg.name}: imports and exports ${pkg.probe}()`, result.ok ? '' : result.output.slice(0, 300));
   }
+
+  await writeFile(
+    join(consumer, 'probe-command.mjs'),
+    "import { command } from 'redproof/command';\n"
+    + "if (typeof command !== 'function') throw new Error('missing command export');\n",
+  );
+  const commandImport = tryRun('node', ['probe-command.mjs'], consumer);
+  report(commandImport.ok, 'redproof/command imports at run time', commandImport.ok ? '' : commandImport.output.slice(0, 300));
 
   console.log('\n5. Run the redproof command line tool on a real project');
   run('mkdir', ['-p', join(consumer, 'gates'), join(consumer, 'src')], consumer);
@@ -213,7 +232,11 @@ try {
 
   const tsc = join(REPO, 'node_modules', '.bin', 'tsc');
 
-  const green = "import { defineGate } from 'redproof';\nexport const gate = defineGate;\n";
+  const green = "import { defineGate, defineRule } from 'redproof';\n"
+    + "import { command } from 'redproof/command';\n"
+    + "const rule = defineRule({ id: 'consumer/command', description: 'command succeeds' });\n"
+    + "export const check = command({ rule, command: 'node' });\n"
+    + "export const gate = defineGate;\n";
   await writeFile(join(consumer, 'consumer.ts'), green);
   const typesOk = tryRun(tsc, ['-p', 'tsconfig.json'], consumer);
   report(typesOk.ok, 'valid consumer code type-checks', typesOk.ok ? '' : typesOk.output.slice(0, 400));

--- a/tests/command.test.ts
+++ b/tests/command.test.ts
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import { mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import test from 'node:test';
+import { command, type CommandCheckOptions } from 'redproof/command';
+import { defineRule } from 'redproof';
+import { withWorkspace } from './helpers/workspace.ts';
+
+const rule = defineRule({
+  id: 'command/succeeds',
+  description: 'The command must succeed.',
+});
+
+async function runNode(
+  source: string,
+  options: Partial<CommandCheckOptions<typeof rule.id>> = {},
+) {
+  return withWorkspace(async root => command({
+    rule,
+    command: process.execPath,
+    args: ['-e', source],
+    ...options,
+  }).run({ root, rules: [rule.id] }));
+}
+
+test('command maps exit zero to PASS without forwarding captured output', async () => {
+  const checkResult = await runNode("process.stdout.write('captured output')");
+  assert.equal(checkResult.verdict, 'pass');
+  assert.equal(checkResult.scan.inspected, 1);
+});
+
+test('command maps a nonzero exit to a targeted Breach with captured output', async () => {
+  const checkResult = await runNode(
+    "process.stdout.write('out'); process.stderr.write('err'); process.exit(3)",
+    { label: 'guardrail' },
+  );
+
+  assert.equal(checkResult.verdict, 'fail');
+  if (checkResult.verdict !== 'fail') return;
+  assert.equal(checkResult.breaches[0].rule, rule.id);
+  assert.equal(checkResult.breaches[0].code, 'command-exit');
+  assert.match(checkResult.breaches[0].detail ?? '', /exit code: 3/);
+  assert.match(checkResult.breaches[0].detail ?? '', /stdout:\nout/);
+  assert.match(checkResult.breaches[0].detail ?? '', /stderr:\nerr/);
+});
+
+test('command refuses an exit code not named by an explicit policy', async () => {
+  const checkResult = await runNode('process.exit(2)', {
+    exitCodes: { pass: [0], breach: [1] },
+  });
+
+  assert.equal(checkResult.verdict, 'refuse');
+  if (checkResult.verdict !== 'refuse') return;
+  assert.equal(checkResult.why.code, 'command-exit-unclassified');
+});
+
+test('command refuses when the executable cannot start', async () => {
+  const checkResult = await withWorkspace(async root => command({
+    rule,
+    command: 'redproof-command-that-does-not-exist',
+  }).run({ root, rules: [rule.id] }));
+
+  assert.equal(checkResult.verdict, 'refuse');
+  if (checkResult.verdict !== 'refuse') return;
+  assert.equal(checkResult.why.code, 'command-unavailable');
+});
+
+test('command refuses when execution exceeds its timeout', async () => {
+  const checkResult = await runNode('setInterval(() => {}, 1_000)', { timeoutMs: 30 });
+
+  assert.equal(checkResult.verdict, 'refuse');
+  if (checkResult.verdict !== 'refuse') return;
+  assert.equal(checkResult.why.code, 'command-timeout');
+});
+
+test('command refuses when execution is terminated by a signal', async () => {
+  const checkResult = await runNode("process.kill(process.pid, 'SIGTERM')");
+
+  assert.equal(checkResult.verdict, 'refuse');
+  if (checkResult.verdict !== 'refuse') return;
+  assert.equal(checkResult.why.code, 'command-signaled');
+});
+
+test('command refuses when combined output exceeds its bound', async () => {
+  const checkResult = await runNode("process.stdout.write('x'.repeat(1_024))", {
+    maxOutputBytes: 32,
+  });
+
+  assert.equal(checkResult.verdict, 'refuse');
+  if (checkResult.verdict !== 'refuse') return;
+  assert.equal(checkResult.why.code, 'command-output-limit');
+  assert.match(checkResult.why.detail ?? '', new RegExp(`stdout:\\n${'x'.repeat(32)}`));
+});
+
+test('command refuses a working directory outside the Gate root', async () => {
+  const checkResult = await runNode('process.exit(0)', { cwd: '..' });
+
+  assert.equal(checkResult.verdict, 'refuse');
+  if (checkResult.verdict !== 'refuse') return;
+  assert.equal(checkResult.why.code, 'command-cwd-outside-root');
+});
+
+test('command resolves cwd inside the Gate root and merges environment overrides', async () => {
+  await withWorkspace(async root => {
+    const cwd = join(root, 'nested');
+    await mkdir(cwd);
+    const checkResult = await command({
+      rule,
+      command: process.execPath,
+      args: [
+        '-e',
+        "if (!process.cwd().endsWith('nested') || process.env.GUARDRAIL !== 'enabled') process.exit(1)",
+      ],
+      cwd: 'nested',
+      env: { GUARDRAIL: 'enabled' },
+    }).run({ root, rules: [rule.id] });
+
+    assert.equal(checkResult.verdict, 'pass');
+  });
+});
+
+test('command validates ambiguous and unsafe options at composition time', () => {
+  assert.throws(
+    () => command({ rule, command: process.execPath, exitCodes: { pass: [0, 1], breach: [1] } }),
+    /cannot produce both PASS and a Breach/,
+  );
+  assert.throws(
+    () => command({ rule, command: process.execPath, timeoutMs: 0 }),
+    /timeoutMs must be a positive integer/,
+  );
+  assert.throws(
+    () => command({ rule, command: ' ' }),
+    /command must not be empty/,
+  );
+});

--- a/tests/helpers/workspace.ts
+++ b/tests/helpers/workspace.ts
@@ -2,10 +2,10 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-export async function withWorkspace(fn: (root: string) => Promise<void>): Promise<void> {
+export async function withWorkspace<T>(fn: (root: string) => Promise<T>): Promise<T> {
   const root = await mkdtemp(join(tmpdir(), 'redproof-test-'));
   try {
-    await fn(root);
+    return await fn(root);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -1,6 +1,7 @@
 import { vitest } from '@redproof/testing';
 import { dependencyCruiser } from '@redproof/dependency-cruiser';
 import { stryker } from '@redproof/stryker';
+import { command } from 'redproof/command';
 import {
   counting,
   defineAdapter,
@@ -39,6 +40,14 @@ const scan: Scan = {
 
 const R1 = defineRule({ id: 'r1', description: 'R1' });
 const R2 = defineRule({ id: 'r2', description: 'R2' });
+
+const commandCheck: Check<'r1'> = command({
+  rule: R1,
+  command: 'npm',
+  args: ['run', 'lint'],
+  exitCodes: { pass: [0], breach: [1] },
+});
+void commandCheck;
 
 const diagnostic: Diagnostic = {
   code: 'x',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,9 @@
       "redproof": [
         "packages/redproof/src/index.ts"
       ],
+      "redproof/command": [
+        "packages/redproof/src/command.ts"
+      ],
       "@redproof/eslint": [
         "packages/eslint/src/index.ts"
       ],


### PR DESCRIPTION
## Problem

Projects often expose guardrails only as executables. Redproof users currently have to rebuild process execution, exit classification, output capture, and PASS/FAIL/REFUSE mapping in every Gate.

## Fix

Add an official redproof/command subpath with a typed command() Check factory.

- Exit 0 passes and ordinary nonzero exits breach the selected Rule by default.
- Explicit pass and breach exit-code policies leave unknown exits as REFUSE.
- Spawn errors, timeouts, signals, and bounded-output overflow produce REFUSE.
- Child stdout and stderr are captured for diagnostics and never inherited by reporter stdout.
- Relative working directories remain inside the Gate root.
- Environment overrides, labels, descriptions, and output limits are configurable.
- README and composition documentation cover the public contract.
- Tarball verification checks runtime and type imports from a clean consumer.

## Verification

After rebasing onto main with PRs #1-#6 merged:

- npm run build
- npm run typecheck
- npm run test:command (10/10 foundation tests passing)
- npm test (114/114 passing on the complete stack)
- npm run verify:package (all package checks passed)