### PR TITLE
Add deterministic multi-command Checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ const gate = defineGate({
 });
 ```
 
-Completed failure exits breach the selected Rule. Missing executables, timeouts, signals, output overflow, and explicitly unclassified exits produce **REFUSE**.
+Completed failure exits breach the selected Rule. Missing executables, timeouts, signals, output overflow, and explicitly unclassified exits produce **REFUSE**. Use `commands()` from the same subpath for deterministic sequential or bounded-parallel command groups.
 
 See **[Composing Redproof](https://github.com/schalermthai/redproof/blob/main/docs/composition.md)** to create your own Gates, Rules, Checks, Proofs, Mutations, and Adapters.
 

--- a/docs/composition.md
+++ b/docs/composition.md
@@ -391,6 +391,34 @@ const check = command({
 
 Here, exit code `2` produces REFUSE because it is neither a passing nor a breach exit. Child stdout and stderr are captured for diagnostics and never inherited by reporter stdout. Relative `cwd` values resolve inside the Gate workspace and cannot escape it.
 
+Use `commands()` when one Gate depends on several executables. Sequential execution is the safe default:
+
+```ts
+import { commands } from 'redproof/command';
+
+const check = commands({
+  entries: [
+    { rule: rules.metadata, command: 'npm', args: ['run', 'lint:package-json'] },
+    { rule: rules.ordering, command: 'npm', args: ['run', 'lint:package-json-sorting'] },
+  ],
+});
+```
+
+Parallel execution is explicit and bounded:
+
+```ts
+const check = commands({
+  mode: 'parallel',
+  maxAtOnce: 2,
+  entries: [
+    { rule: rules.docs, command: 'npm', args: ['run', 'lint:docs'] },
+    { rule: rules.types, command: 'npm', args: ['run', 'lint:types'] },
+  ],
+});
+```
+
+Results remain in declaration order even when commands finish in a different order. Sequential execution stops at the first REFUSE. Parallel execution waits for the started group, and REFUSE takes precedence over collected Breaches because the Gate could not make a complete decision.
+
 ## Creating an Adapter
 
 Use an Adapter when an external system introduces its own policy model.

--- a/packages/redproof/src/command.ts
+++ b/packages/redproof/src/command.ts
@@ -29,6 +29,23 @@ export type CommandCheckOptions<R extends RuleRef> = {
   readonly exitCodes?: CommandExitCodes;
 };
 
+export type CommandGroupExecution =
+  | {
+      readonly mode?: 'sequential';
+      readonly maxAtOnce?: never;
+    }
+  | {
+      readonly mode: 'parallel';
+      /** Maximum number of child processes running together. Defaults to 4. */
+      readonly maxAtOnce?: number;
+    };
+
+export type CommandGroupOptions<R extends RuleRef> = {
+  readonly entries: readonly [CommandCheckOptions<R>, ...CommandCheckOptions<R>[]];
+  readonly label?: string;
+  readonly description?: string;
+} & CommandGroupExecution;
+
 type CompletedCommand = {
   readonly kind: 'completed';
   readonly exitCode: number;
@@ -301,6 +318,95 @@ export function command<const R extends RuleRef>(options: CommandCheckOptions<R>
         location: null,
         ...(detail ? { detail } : {}),
       });
+    },
+  };
+}
+
+async function mapLimit<T, R>(
+  items: readonly T[],
+  limit: number,
+  run: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let cursor = 0;
+
+  async function worker(): Promise<void> {
+    for (;;) {
+      const index = cursor;
+      cursor += 1;
+      if (index >= items.length) return;
+      results[index] = await run(items[index]!);
+    }
+  }
+
+  await Promise.all(Array.from(
+    { length: Math.min(limit, items.length) },
+    () => worker(),
+  ));
+  return results;
+}
+
+function groupSource<R extends RuleRef>(options: CommandGroupOptions<R>): string {
+  return options.label
+    ?? options.entries.map(entry => entry.label ?? entry.command).join(', ');
+}
+
+function aggregateResults<R extends RuleRef>(
+  outcomes: readonly CheckResult<R>[],
+  source: string,
+  startedAt: string,
+): CheckResult<R> {
+  const aggregateScan: Scan = {
+    source,
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    inspected: outcomes.length,
+  };
+  const refused = outcomes.find(outcome => outcome.verdict === 'refuse');
+  if (refused?.verdict === 'refuse') {
+    return result.refuse(aggregateScan, refused.why);
+  }
+
+  const breaches = outcomes.flatMap(outcome =>
+    outcome.verdict === 'fail' ? outcome.breaches : []
+  );
+  return result.fromBreaches(aggregateScan, breaches);
+}
+
+/** Create one Check from multiple commands with deterministic sequential or bounded-parallel aggregation. */
+export function commands<const R extends RuleRef>(options: CommandGroupOptions<R>): Check<R> {
+  if (options.entries.length === 0) throw new Error('commands requires at least one entry.');
+  if (options.mode !== 'parallel' && options.maxAtOnce !== undefined) {
+    throw new Error('maxAtOnce is only available in parallel mode.');
+  }
+  if (options.mode === 'parallel') validatePositiveInteger('maxAtOnce', options.maxAtOnce);
+
+  const checks = options.entries.map(entry => command(entry));
+  const source = groupSource(options);
+
+  return {
+    description: options.description ?? `run ${checks.length} commands`,
+    counting: counting.supported,
+
+    async run(ctx): Promise<CheckResult<R>> {
+      const startedAt = new Date().toISOString();
+
+      if (options.mode === 'parallel') {
+        const outcomes = await mapLimit(
+          checks,
+          options.maxAtOnce ?? 4,
+          check => check.run(ctx),
+        );
+        return aggregateResults(outcomes, source, startedAt);
+      }
+
+      const outcomes: CheckResult<R>[] = [];
+      for (const check of checks) {
+        const outcome = await check.run(ctx);
+        outcomes.push(outcome);
+        if (outcome.verdict === 'refuse') break;
+      }
+      return aggregateResults(outcomes, source, startedAt);
     },
   };
 }

--- a/scripts/verify-package.ts
+++ b/scripts/verify-package.ts
@@ -152,8 +152,9 @@ try {
 
   await writeFile(
     join(consumer, 'probe-command.mjs'),
-    "import { command } from 'redproof/command';\n"
-    + "if (typeof command !== 'function') throw new Error('missing command export');\n",
+    "import { command, commands } from 'redproof/command';\n"
+    + "if (typeof command !== 'function') throw new Error('missing command export');\n"
+    + "if (typeof commands !== 'function') throw new Error('missing commands export');\n",
   );
   const commandImport = tryRun('node', ['probe-command.mjs'], consumer);
   report(commandImport.ok, 'redproof/command imports at run time', commandImport.ok ? '' : commandImport.output.slice(0, 300));
@@ -233,9 +234,10 @@ try {
   const tsc = join(REPO, 'node_modules', '.bin', 'tsc');
 
   const green = "import { defineGate, defineRule } from 'redproof';\n"
-    + "import { command } from 'redproof/command';\n"
+    + "import { command, commands } from 'redproof/command';\n"
     + "const rule = defineRule({ id: 'consumer/command', description: 'command succeeds' });\n"
     + "export const check = command({ rule, command: 'node' });\n"
+    + "export const group = commands({ entries: [{ rule, command: 'node' }] });\n"
     + "export const gate = defineGate;\n";
   await writeFile(join(consumer, 'consumer.ts'), green);
   const typesOk = tryRun(tsc, ['-p', 'tsconfig.json'], consumer);

--- a/tests/command.test.ts
+++ b/tests/command.test.ts
@@ -1,14 +1,18 @@
 import assert from 'node:assert/strict';
-import { mkdir } from 'node:fs/promises';
+import { mkdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import test from 'node:test';
-import { command, type CommandCheckOptions } from 'redproof/command';
+import { command, commands, type CommandCheckOptions } from 'redproof/command';
 import { defineRule } from 'redproof';
 import { withWorkspace } from './helpers/workspace.ts';
 
 const rule = defineRule({
   id: 'command/succeeds',
   description: 'The command must succeed.',
+});
+const secondRule = defineRule({
+  id: 'command/second-succeeds',
+  description: 'The second command must succeed.',
 });
 
 async function runNode(
@@ -131,5 +135,154 @@ test('command validates ambiguous and unsafe options at composition time', () =>
   assert.throws(
     () => command({ rule, command: ' ' }),
     /command must not be empty/,
+  );
+});
+
+test('commands runs sequential entries in declaration order', async () => {
+  await withWorkspace(async root => {
+    const append = (value: string): CommandCheckOptions<typeof rule.id> => ({
+      rule,
+      command: process.execPath,
+      args: ['-e', `require('node:fs').appendFileSync('order.txt', '${value}')`],
+    });
+    const checkResult = await commands({
+      entries: [append('A'), append('B')],
+    }).run({ root, rules: [rule.id] });
+
+    assert.equal(checkResult.verdict, 'pass');
+    assert.equal(await readFile(join(root, 'order.txt'), 'utf8'), 'AB');
+    assert.equal(checkResult.scan.inspected, 2);
+  });
+});
+
+test('commands stops sequential execution when an entry refuses', async () => {
+  await withWorkspace(async root => {
+    const checkResult = await commands({
+      entries: [
+        { rule, command: 'redproof-command-that-does-not-exist', label: 'missing' },
+        {
+          rule,
+          command: process.execPath,
+          args: ['-e', "require('node:fs').writeFileSync('should-not-exist.txt', '')"],
+        },
+      ],
+    }).run({ root, rules: [rule.id] });
+
+    assert.equal(checkResult.verdict, 'refuse');
+    assert.equal(checkResult.scan.inspected, 1);
+    await assert.rejects(readFile(join(root, 'should-not-exist.txt')));
+  });
+});
+
+test('commands starts entries concurrently in parallel mode', async () => {
+  await withWorkspace(async root => {
+    const rendezvous = `
+      const { existsSync, writeFileSync } = require('node:fs');
+      const [own, other] = process.argv.slice(1);
+      writeFileSync(own, '');
+      const deadline = Date.now() + 2_000;
+      const timer = setInterval(() => {
+        if (existsSync(other)) process.exit(0);
+        if (Date.now() > deadline) process.exit(1);
+      }, 10);
+    `;
+    const checkResult = await commands({
+      mode: 'parallel',
+      maxAtOnce: 2,
+      entries: [
+        { rule, command: process.execPath, args: ['-e', rendezvous, 'a.started', 'b.started'] },
+        { rule, command: process.execPath, args: ['-e', rendezvous, 'b.started', 'a.started'] },
+      ],
+    }).run({ root, rules: [rule.id] });
+
+    assert.equal(checkResult.verdict, 'pass');
+    assert.equal(checkResult.scan.inspected, 2);
+  });
+});
+
+test('commands respects the parallel maxAtOnce bound', async () => {
+  await withWorkspace(async root => {
+    const checkResult = await commands({
+      mode: 'parallel',
+      maxAtOnce: 1,
+      entries: [
+        {
+          rule,
+          command: process.execPath,
+          args: [
+            '-e',
+            "setTimeout(() => require('node:fs').appendFileSync('bounded.txt', 'A'), 80)",
+          ],
+        },
+        {
+          rule,
+          command: process.execPath,
+          args: ['-e', "require('node:fs').appendFileSync('bounded.txt', 'B')"],
+        },
+      ],
+    }).run({ root, rules: [rule.id] });
+
+    assert.equal(checkResult.verdict, 'pass');
+    assert.equal(await readFile(join(root, 'bounded.txt'), 'utf8'), 'AB');
+  });
+});
+
+test('commands keeps parallel Breaches in declaration order', async () => {
+  await withWorkspace(async root => {
+    const checkResult = await commands({
+      mode: 'parallel',
+      maxAtOnce: 2,
+      entries: [
+        {
+          rule,
+          label: 'slow first',
+          command: process.execPath,
+          args: ['-e', 'setTimeout(() => process.exit(1), 60)'],
+        },
+        {
+          rule: secondRule,
+          label: 'fast second',
+          command: process.execPath,
+          args: ['-e', 'process.exit(1)'],
+        },
+      ],
+    }).run({ root, rules: [rule.id, secondRule.id] });
+
+    assert.equal(checkResult.verdict, 'fail');
+    if (checkResult.verdict !== 'fail') return;
+    assert.deepEqual(
+      checkResult.breaches.map(item => [item.rule, item.message]),
+      [
+        [rule.id, 'slow first exited with code 1.'],
+        [secondRule.id, 'fast second exited with code 1.'],
+      ],
+    );
+  });
+});
+
+test('commands makes REFUSE dominate parallel Breaches', async () => {
+  await withWorkspace(async root => {
+    const checkResult = await commands({
+      mode: 'parallel',
+      entries: [
+        { rule, command: process.execPath, args: ['-e', 'process.exit(1)'] },
+        { rule: secondRule, command: 'redproof-command-that-does-not-exist' },
+      ],
+    }).run({ root, rules: [rule.id, secondRule.id] });
+
+    assert.equal(checkResult.verdict, 'refuse');
+    if (checkResult.verdict !== 'refuse') return;
+    assert.equal(checkResult.why.code, 'command-unavailable');
+  });
+});
+
+test('commands validates its execution policy at composition time', () => {
+  assert.throws(
+    () => commands({ entries: [] as never }),
+    /requires at least one entry/,
+  );
+  assert.throws(
+    () => commands({ mode: 'parallel', maxAtOnce: 0, entries: [{ rule, command: 'node' }] }),
+    /maxAtOnce must be a positive integer/,
   );
 });

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -1,7 +1,7 @@
 import { vitest } from '@redproof/testing';
 import { dependencyCruiser } from '@redproof/dependency-cruiser';
 import { stryker } from '@redproof/stryker';
-import { command } from 'redproof/command';
+import { command, commands } from 'redproof/command';
 import {
   counting,
   defineAdapter,
@@ -48,6 +48,16 @@ const commandCheck: Check<'r1'> = command({
   exitCodes: { pass: [0], breach: [1] },
 });
 void commandCheck;
+
+const commandGroup: Check<'r1' | 'r2'> = commands({
+  mode: 'parallel',
+  maxAtOnce: 2,
+  entries: [
+    { rule: R1, command: 'npm', args: ['run', 'lint'] },
+    { rule: R2, command: 'npm', args: ['test'] },
+  ],
+});
+void commandGroup;
 
 const diagnostic: Diagnostic = {
   code: 'x',


### PR DESCRIPTION
## Stack

This PR builds on #7. Merge #7 first; this PR can then be retargeted to main.

## Problem

A Gate may depend on several executable guardrails. Users need an official way to run them safely without rewriting sequencing, concurrency, result ordering, and REFUSE precedence.

## Fix

Add commands() to redproof/command.

- Sequential execution is the safe default.
- Sequential groups stop at the first REFUSE.
- Parallel execution is explicit and bounded with maxAtOnce (default 4).
- Aggregated Breaches remain in declaration order even when processes finish out of order.
- REFUSE dominates parallel Breaches when any command cannot produce a trustworthy result.
- Aggregate scans report the number of attempted command policy units.
- Mixed Rules retain their literal union in the returned Check type.
- Documentation and packed-consumer probes cover the expanded subpath API.

## Verification

After rebasing onto main with PRs #1-#6 merged:

- npm run build
- npm run typecheck
- npm run test:command (17/17 passing)
- npm test (114/114 passing)
- npm run verify:package (all package checks passed)