### PR TITLE
Run the project check on every push and pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+# Every push to main and every pull request runs the same gate the release runs.
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# A new push to the same branch cancels the run it replaces.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check and verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24.x'
+          cache: 'npm'
+
+      - name: Show tool versions
+        run: |
+          echo "node: $(node --version)"
+          echo "npm:  $(npm --version)"
+
+      # `npm ci` also proves package.json and package-lock.json still agree.
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run the full project check
+        run: npm run check
+
+      # Rebuilt on purpose. Package verification must never read a stale dist.
+      - name: Build the production artifact
+        run: npm run build
+
+      - name: Verify the packages a consumer would install
+        run: npm run verify:package


### PR DESCRIPTION
## Problem

The repository has only a publish workflow. It runs on a release or a manual trigger.

Nothing runs `npm run check` on a push or a pull request. Two merged pull requests shipped breaks that no gate caught:

- PR #4 added a workspace fixture without updating `package-lock.json`. `npm ci` then failed.
- PR #7 added the `redproof/command` subpath without a `tsconfig.json` path entry. `npm run check` then failed on a clean checkout with TS2307.

Both were found by hand. Both would have failed the release.

## Fix

Add `.github/workflows/ci.yml`. It runs on every push to `main` and on every pull request.

Steps: `npm ci`, `npm run check`, `npm run build`, `npm run verify:package`.

- `npm ci` proves `package.json` and `package-lock.json` still agree. This catches the PR #4 class.
- `npm run check` runs `typecheck` before any build exists. This catches the PR #7 class.
- The build is explicit before `verify:package`, so package verification never reads a stale `dist`.
- Node 24, the version `engines` requires.
- Concurrency cancels a run that a newer push replaces.

## Verification

Timed locally on a clean checkout: `npm run check` 10.5s, `npm run verify:package` 18.6s.

The red proof for this gate is recorded in the comments below.