### PR TITLE
Preserve nested package fixtures in copy mode

### DIFF
--- a/packages/redproof/src/runtime/workspace.ts
+++ b/packages/redproof/src/runtime/workspace.ts
@@ -23,9 +23,9 @@ export type GateWorkspace = {
   readonly baseline: TreeStamp;
 };
 
-const OMIT_FROM_COPY = new Set(['.git', '.redproof', 'node_modules']);
+const OMIT_FROM_COPY = new Set(['.git', '.redproof']);
 
-async function copyEntry(source: string, target: string): Promise<void> {
+async function copyEntry(source: string, target: string, sourceRoot: string): Promise<void> {
   const info = await lstat(source);
 
   if (info.isDirectory()) {
@@ -33,8 +33,11 @@ async function copyEntry(source: string, target: string): Promise<void> {
     await chmod(target, info.mode);
     const entries = await readdir(source, { withFileTypes: true });
     for (const entry of entries) {
-      if (OMIT_FROM_COPY.has(entry.name)) continue;
-      await copyEntry(join(source, entry.name), join(target, entry.name));
+      if (
+        OMIT_FROM_COPY.has(entry.name)
+        || (source === sourceRoot && entry.name === 'node_modules')
+      ) continue;
+      await copyEntry(join(source, entry.name), join(target, entry.name), sourceRoot);
     }
     return;
   }
@@ -156,9 +159,10 @@ async function linkDependencies(projectRoot: string, target: string): Promise<vo
 
 export async function copyGateWorkspace(projectRoot: string, gateId: string): Promise<GateWorkspace> {
   const target = await createCopyRoot(gateId);
+  const sourceRoot = resolve(projectRoot);
 
-  await copyEntry(projectRoot, target);
-  await linkDependencies(projectRoot, target);
+  await copyEntry(sourceRoot, target, sourceRoot);
+  await linkDependencies(sourceRoot, target);
   const baseline = await stampTree(target);
   return { root: target, baseline };
 }

--- a/tests/workspace.test.ts
+++ b/tests/workspace.test.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import { lstat, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import {
+  copyGateWorkspace,
+  releaseGateWorkspace,
+} from '../packages/redproof/src/runtime/workspace.ts';
+import { withWorkspace } from './helpers/workspace.ts';
+
+test('copies tracked nested node_modules fixtures while linking root dependencies', async () => {
+  await withWorkspace(async root => {
+    const nestedFixture = join(
+      root,
+      'test/fixtures/node_modules/example-package/package.json',
+    );
+    await mkdir(join(root, 'node_modules/root-package'), { recursive: true });
+    await mkdir(join(root, '.git'), { recursive: true });
+    await mkdir(join(root, '.redproof'), { recursive: true });
+    await mkdir(join(nestedFixture, '..'), { recursive: true });
+    await writeFile(
+      nestedFixture,
+      '{"name":"example-package","version":"1.0.0"}\n',
+      'utf8',
+    );
+
+    const workspace = await copyGateWorkspace(root, 'nested-node-modules');
+    try {
+      assert.equal(
+        await readFile(
+          join(
+            workspace.root,
+            'test/fixtures/node_modules/example-package/package.json',
+          ),
+          'utf8',
+        ),
+        '{"name":"example-package","version":"1.0.0"}\n',
+      );
+      assert.equal((await lstat(join(workspace.root, 'node_modules'))).isSymbolicLink(), true);
+      await assert.rejects(lstat(join(workspace.root, '.git')));
+      await assert.rejects(lstat(join(workspace.root, '.redproof')));
+    } finally {
+      await releaseGateWorkspace(workspace);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- omit and link only the project-root node_modules directory in copies mode
- preserve nested node_modules trees used as source-controlled package fixtures
- retain recursive omission of .git and .redproof directories

## Battle-test reproduction

dependency-cruiser tracks miniature packages under test/**/node_modules. Published Redproof 0.6.0 removed those directories from Gate copies, causing its 961-test unit slice to REFUSE before producing a JUnit report.

## Verification

- npm run typecheck
- focused workspace regression passes
- npm test: 115/115
- real dependency-cruiser fixture progresses past the missing-module refusal and runs the nested package tests