### PR TITLE
Decode numeric entities in JUnit reports

### DIFF
--- a/packages/testing/src/reports/junit-xml.ts
+++ b/packages/testing/src/reports/junit-xml.ts
@@ -2,6 +2,12 @@ import type { TestCase, TestReportFormat, TestRun } from '../model.ts';
 
 function decodeXml(value: string): string {
   return value
+    .replace(/&#(?:x([0-9a-f]+)|(\d+));/gi, (reference, hex, decimal) => {
+      const codePoint = Number.parseInt(hex ?? decimal, hex ? 16 : 10);
+      return codePoint <= 0x10FFFF && !(codePoint >= 0xD800 && codePoint <= 0xDFFF)
+        ? String.fromCodePoint(codePoint)
+        : reference;
+    })
     .replaceAll('&lt;', '<')
     .replaceAll('&gt;', '>')
     .replaceAll('&quot;', '"')

--- a/tests/adapters/testing.test.ts
+++ b/tests/adapters/testing.test.ts
@@ -77,6 +77,18 @@ test('JUnit XML normalizes passed, failed and skipped tests', () => {
   assert.deepEqual(run.tests[1]?.suite, ['test_parser']);
 });
 
+test('JUnit XML decodes named, decimal, and hexadecimal character references', () => {
+  const run = parseJunitXml(`<testsuite name="entities">
+    <testcase classname="suite" name="it&#x27;s safe">
+      <failure message="&#60;bad&#62; &amp; &#128640;">at &#x3C;anonymous&#x3E;</failure>
+    </testcase>
+  </testsuite>`);
+
+  assert.equal(run.tests[0]?.name, "it's safe");
+  assert.equal(run.tests[0]?.failure?.message, '<bad> & 🚀');
+  assert.equal(run.tests[0]?.failure?.detail, 'at <anonymous>');
+});
+
 test('generic test semantics map statuses to distinct Redproof rules', () => {
   const testsPass = defineRule({ id: 'testing/tests-pass', description: 'tests pass' });
   const noSkippedTests = defineRule({ id: 'testing/no-skipped-tests', description: 'no skip' });


### PR DESCRIPTION
## Summary

- decode decimal XML character references in JUnit attributes and failure text
- decode hexadecimal XML character references emitted by Mocha XUnit
- leave invalid Unicode scalar references unchanged

## Battle-test reproduction

Mocha XUnit emits values such as &#x27; and &#x3C;. The testing adapter preserved those encodings in test names and diagnostics instead of displaying apostrophes and angle brackets.

## Verification

- npm run typecheck
- npm run test:testing: 8/8
- npm test: 115/115