### PR TITLE
Cover the two untested guards in the JUnit entity decoder

### DIFF
--- a/tests/adapters/testing.test.ts
+++ b/tests/adapters/testing.test.ts
@@ -89,6 +89,22 @@ test('JUnit XML decodes named, decimal, and hexadecimal character references', (
   assert.equal(run.tests[0]?.failure?.detail, 'at <anonymous>');
 });
 
+test('JUnit XML leaves out-of-range and surrogate references undecoded', () => {
+  const run = parseJunitXml(`<testsuite name="entities">
+    <testcase classname="suite" name="over &#x110000; and lone &#xD800;"/>
+  </testsuite>`);
+
+  assert.equal(run.tests[0]?.name, 'over &#x110000; and lone &#xD800;');
+});
+
+test('JUnit XML does not decode an escaped character reference twice', () => {
+  const run = parseJunitXml(`<testsuite name="entities">
+    <testcase classname="suite" name="literal &amp;#60;tag&amp;#62;"/>
+  </testsuite>`);
+
+  assert.equal(run.tests[0]?.name, 'literal &#60;tag&#62;');
+});
+
 test('generic test semantics map statuses to distinct Redproof rules', () => {
   const testsPass = defineRule({ id: 'testing/tests-pass', description: 'tests pass' });
   const noSkippedTests = defineRule({ id: 'testing/no-skipped-tests', description: 'no skip' });


### PR DESCRIPTION
## Problem

#12 added numeric character reference decoding to `packages/testing/src/reports/junit-xml.ts`. The code has four guards. Its test covers only two.

I found this by mutation. Two mutations left the whole suite green:

| Mutation | Suite result |
|---|---|
| Removed the range and surrogate guard | 8 of 8 passed |
| Moved the numeric decode after the named decodes | 8 of 8 passed |

Both guards protect real behaviour. Measured against the built parser:

| Input | Real code | Guard removed |
|---|---|---|
| `a&#x110000;b` | `a&#x110000;b` | **throws `RangeError: Invalid code point 1114112`** |
| `a&#xD800;b` | `a&#xD800;b` | `a\ud800b` |
| `a&amp;#60;b` | `a&#60;b` | **`a<b`** (decode order mutation) |

The range case is a crash. `String.fromCodePoint` throws above `0x10FFFF`. A JUnit report from any other tool can contain such a reference. The Gate would then fail for the wrong reason.

The order case is a silent double decode. It corrupts a test name that legitimately contains the text `&#60;`.

## Fix

Add two test cases to `tests/adapters/testing.test.ts`. No source change.

## Verification

Green on unchanged code: 118 tests, 118 pass, 0 fail. `npm run check` exit 0.

Red proof, one mutation per test:

| Mutation | Failed test | What the failure said |
|---|---|---|
| Range and surrogate guard removed | `leaves out-of-range and surrogate references undecoded` | `RangeError: Invalid code point 1114112` |
| Numeric decode moved last | `does not decode an escaped character reference twice` | `+ actual 'literal <tag>'` |

Each mutation killed exactly one new test and left the other 9 passing.