### PR TITLE
Fix the Gate example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ const gate = defineGate({
     counting: counting.supported,
 
     async run(ctx) {
+      const startedAt = new Date().toISOString();
 
       // scan all Typescript to find //TODO comment
       const found = await text.find(ctx, {
@@ -91,9 +92,17 @@ const gate = defineGate({
         find: /\bTODO\b/g,
       });
 
+      // describe what the Check inspected
+      const scan = {
+        source: 'text',
+        startedAt,
+        finishedAt: new Date().toISOString(),
+        inspected: found.files.length,
+      };
+
       // should detect a breach
       return result.fromBreaches(
-        found.scan,
+        scan,
         found.matches.map(match =>
           breach(rules.noTodo, {
             code: 'todo-found',


### PR DESCRIPTION
## Problem

The "A small Gate" example in the README does not compile. It is the first code a new user copies.

It passes `found.scan` to `result.fromBreaches`. `text.find` returns a `TextSearch`, which has only `files` and `matches`. There is no `scan` on it.

Extracting the block and running the type checker gives:

```
readme-gate.ts(42,15): error TS2339: Property 'scan' does not exist on type 'TextSearch'.
```

## Fix

Build the `Scan` in the example, the same way `fixtures/composition-native/gates/no-todo.ts` does.

```ts
const startedAt = new Date().toISOString();

const found = await text.find(ctx, {
  files: 'src/**/*.ts',
  find: /\bTODO\b/g,
});

const scan = {
  source: 'text',
  startedAt,
  finishedAt: new Date().toISOString(),
  inspected: found.files.length,
};

return result.fromBreaches(scan, ...);
```

No source change. Nine lines in one file.

## Verification

I extracted the example into a scratch file under `tests/`, where the root `tsconfig.json` already applies, and ran `npm run typecheck`.

| State | Result |
|---|---|
| README as written before this change | RED — `TS2339: Property 'scan' does not exist on type 'TextSearch'` |
| README after this change | GREEN — 0 errors |
| Old mistake put back on purpose | RED — same TS2339 |
| Restored again | GREEN — 0 errors |

I then extracted all 45 TypeScript blocks from `README.md`, `docs/composition.md`, `docs/adapters.md`, and the three tutorials, and type-checked them together. The remaining 14 errors are all `TS1005`, `TS1109`, and `TS1128`. Those come from blocks that are deliberate fragments, such as a bare `check: { ... }` object. No semantic error is left in any doc.

`npm run check` exit 0. 127 tests, 127 pass, 0 fail.
`npm run verify:package` exit 0. 50 PASS, 0 FAIL.