### PR TITLE
Let a search describe itself as a Scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ const gate = defineGate({
 
       // should detect a breach
       return result.fromBreaches(
-        found.scan,
+        found.scan(),
         found.matches.map(match =>
           breach(rules.noTodo, {
             code: 'todo-found',

--- a/docs/composition.md
+++ b/docs/composition.md
@@ -179,6 +179,49 @@ const first = await text.findFirst(ctx, {
 });
 ```
 
+## Describing a search
+
+`text.find` and `json.query` both return a `scan()` function. It describes that one search:
+
+```ts
+const found = await text.find(ctx, { files: 'src/**/*.ts', find: /\bTODO\b/g });
+
+return result.fromBreaches(found.scan(), breaches);
+```
+
+`scan()` records the window of the search itself. `inspected` counts the files that search read. `source` is `'text'` or `'json'`.
+
+Override either default when it helps:
+
+```ts
+found.scan({ source: 'todo-scan' })
+```
+
+Pass `startedAt` when the Check began working before the search:
+
+```ts
+async run(ctx) {
+  const startedAt = new Date().toISOString();
+  const policy = JSON.parse(await files.read(ctx, 'policy.json'));
+  const found = await text.find(ctx, { files: 'src/**/*.ts', find: policy.marker });
+
+  return result.fromBreaches(found.scan({ startedAt }), breaches);
+}
+```
+
+**One `scan()` describes one search.** A Check that runs several searches must build its own `Scan`, or `inspected` will under-count:
+
+```ts
+const scan = {
+  source: 'markers',
+  startedAt,
+  finishedAt: new Date().toISOString(),
+  inspected: new Set([...todos.files, ...fixmes.files]).size,
+};
+```
+
+That matters because a Check declaring `counting.supported` promises a reliable count.
+
 ## Proofs
 
 A RED proof targets one specific Rule:

--- a/fixtures/composition-json/gates/test-command.ts
+++ b/fixtures/composition-json/gates/test-command.ts
@@ -26,17 +26,10 @@ const gate = defineGate({
     counting: counting.supported,
 
     async run(ctx) {
-      const startedAt = new Date().toISOString();
       const found = await json.query(ctx, {
         files: 'config/policy.json',
         path: '$.scripts.test',
       });
-      const scan = {
-        source: 'json',
-        startedAt,
-        finishedAt: new Date().toISOString(),
-        inspected: found.files.length,
-      } as const;
 
       const breaches = found.matches
         .filter(match => match.value !== 'node --test')
@@ -50,7 +43,7 @@ const gate = defineGate({
           },
         }));
 
-      return result.fromBreaches(scan, breaches);
+      return result.fromBreaches(found.scan(), breaches);
     },
   },
 });

--- a/fixtures/composition-native/gates/no-todo.ts
+++ b/fixtures/composition-native/gates/no-todo.ts
@@ -26,20 +26,13 @@ const gate = defineGate({
     counting: counting.supported,
 
     async run(ctx) {
-      const startedAt = new Date().toISOString();
       const found = await text.find(ctx, {
         files: 'src/**/*.ts',
         find: /\bTODO\b/g,
       });
-      const scan = {
-        source: 'text',
-        startedAt,
-        finishedAt: new Date().toISOString(),
-        inspected: found.files.length,
-      } as const;
 
       return result.fromBreaches(
-        scan,
+        found.scan(),
         found.matches.map(match => breach(rules.noTodo, {
           code: 'todo-found',
           message: 'TODO comment found.',

--- a/fixtures/gate-selection/gates/alpha.ts
+++ b/fixtures/gate-selection/gates/alpha.ts
@@ -26,17 +26,10 @@ const gate = defineGate({
     counting: counting.supported,
 
     async run(ctx) {
-      const startedAt = new Date().toISOString();
       const found = await text.find(ctx, { files: 'src/alpha.txt', find: /MARKER/g });
-      const scan = {
-        source: 'alpha',
-        startedAt,
-        finishedAt: new Date().toISOString(),
-        inspected: found.files.length,
-      } as const;
 
       return result.fromBreaches(
-        scan,
+        found.scan({ source: 'alpha' }),
         found.matches.map(match =>
           breach(rules.noMarker, {
             code: 'marker-found',

--- a/fixtures/gate-selection/gates/beta.ts
+++ b/fixtures/gate-selection/gates/beta.ts
@@ -26,17 +26,10 @@ const gate = defineGate({
     counting: counting.supported,
 
     async run(ctx) {
-      const startedAt = new Date().toISOString();
       const found = await text.find(ctx, { files: 'src/beta.txt', find: /MARKER/g });
-      const scan = {
-        source: 'beta',
-        startedAt,
-        finishedAt: new Date().toISOString(),
-        inspected: found.files.length,
-      } as const;
 
       return result.fromBreaches(
-        scan,
+        found.scan({ source: 'beta' }),
         found.matches.map(match =>
           breach(rules.noMarker, {
             code: 'marker-found',

--- a/packages/redproof/src/composition/inspect.ts
+++ b/packages/redproof/src/composition/inspect.ts
@@ -1,5 +1,6 @@
 import { glob, mkdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises';
 import { dirname, matchesGlob, resolve, sep } from 'node:path';
+import type { Scan } from '../domain/check.ts';
 import type { Location } from '../domain/diagnostic.ts';
 
 export type RootContext = { readonly root: string };
@@ -109,9 +110,24 @@ export type FindTextOptions = {
   readonly find: string | RegExp;
 };
 
+export type ScanOptions = {
+  /** Defaults to the search kind, `'text'` or `'json'`. */
+  readonly source?: string;
+  /** Defaults to the moment the search started. Pass an earlier time to widen the window. */
+  readonly startedAt?: string;
+};
+
+/**
+ * Describe one search as a Scan. `inspected` counts the files that search read.
+ * A Check that runs several searches must build its own Scan, or its report
+ * will under-count.
+ */
+export type SearchScan = (options?: ScanOptions) => Scan;
+
 export type TextSearch = {
   readonly files: readonly string[];
   readonly matches: readonly TextMatch[];
+  readonly scan: SearchScan;
 };
 
 function regexFor(find: string | RegExp): RegExp {
@@ -134,7 +150,18 @@ function locationAt(file: string, content: string, offset: number): Location {
   };
 }
 
+function scanner(kind: string, startedAt: string, inspected: number): SearchScan {
+  const finishedAt = new Date().toISOString();
+  return (options = {}) => ({
+    source: options.source ?? kind,
+    startedAt: options.startedAt ?? startedAt,
+    finishedAt,
+    inspected,
+  });
+}
+
 async function findText(ctx: RootContext, options: FindTextOptions): Promise<TextSearch> {
+  const startedAt = new Date().toISOString();
   const paths = await findFiles(ctx, options.files);
   const matches: TextMatch[] = [];
 
@@ -156,7 +183,7 @@ async function findText(ctx: RootContext, options: FindTextOptions): Promise<Tex
     }
   }
 
-  return { files: paths, matches };
+  return { files: paths, matches, scan: scanner('text', startedAt, paths.length) };
 }
 
 async function findFirstText(ctx: RootContext, options: FindTextOptions): Promise<TextMatch | null> {
@@ -249,6 +276,7 @@ export type JsonMatch = {
 export type JsonSearch = {
   readonly files: readonly string[];
   readonly matches: readonly JsonMatch[];
+  readonly scan: SearchScan;
 };
 
 type JsonResolvedMatch = JsonMatch & {
@@ -395,6 +423,7 @@ function resolveJsonDocument(document: unknown, tokens: readonly JsonPathToken[]
 }
 
 async function queryJson(ctx: RootContext, options: FindJsonOptions): Promise<JsonSearch> {
+  const startedAt = new Date().toISOString();
   const paths = await findFiles(ctx, options.files);
   const tokens = parseJsonPath(options.path);
   const matches: JsonMatch[] = [];
@@ -413,7 +442,7 @@ async function queryJson(ctx: RootContext, options: FindJsonOptions): Promise<Js
     }
   }
 
-  return { files: paths, matches };
+  return { files: paths, matches, scan: scanner('json', startedAt, paths.length) };
 }
 
 export const json = {

--- a/tests/composition/api.test.ts
+++ b/tests/composition/api.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import test from 'node:test';
+import { setTimeout } from 'node:timers/promises';
 import {
   breach,
   counting,
@@ -9,6 +10,7 @@ import {
   defineGate,
   defineRules,
   files,
+  json,
   result,
   text,
   type Scan,
@@ -87,5 +89,78 @@ test('files.find and text.find return relative paths plus exact source locations
     assert.equal(found.matches.length, 1);
     assert.deepEqual(found.matches[0]?.location, { file: 'src/a.ts', line: 2, column: 4 });
     assert.deepEqual(found.matches[0]?.range, { start: 16, end: 20 });
+  });
+});
+
+test('a search describes itself as a Scan covering its own window', async () => {
+  await withWorkspace(async root => {
+    await mkdir(join(root, 'src'), { recursive: true });
+    await writeFile(join(root, 'src/a.ts'), '// TODO: a\n', 'utf8');
+    await writeFile(join(root, 'src/b.ts'), 'const b = 2;\n', 'utf8');
+
+    const before = new Date().toISOString();
+    const found = await text.find({ root }, { files: 'src/**/*.ts', find: 'TODO' });
+    const after = new Date().toISOString();
+
+    // The window must describe the search, not the moment scan() is called.
+    await setTimeout(20);
+    const searchScan = found.scan();
+
+    assert.equal(searchScan.source, 'text');
+    assert.equal(searchScan.inspected, 2, 'inspected counts the files read, not the matches');
+    assert.ok(searchScan.startedAt >= before, 'the window cannot start before the search did');
+    assert.ok(searchScan.startedAt <= after, 'the window cannot start after the search ended');
+    assert.ok(searchScan.finishedAt <= after, 'the window cannot end after the search did');
+    assert.ok(searchScan.startedAt <= searchScan.finishedAt);
+  });
+});
+
+test('a search Scan accepts an earlier start and a different source', async () => {
+  await withWorkspace(async root => {
+    await mkdir(join(root, 'src'), { recursive: true });
+    await writeFile(join(root, 'src/a.ts'), '// TODO: a\n', 'utf8');
+
+    const startedAt = '2020-01-01T00:00:00.000Z';
+    const found = await text.find({ root }, { files: 'src/**/*.ts', find: 'TODO' });
+
+    assert.equal(found.scan({ startedAt }).startedAt, startedAt);
+    assert.equal(found.scan({ source: 'todo-scan' }).source, 'todo-scan');
+    assert.notEqual(found.scan().startedAt, startedAt, 'the override must not leak into the default');
+  });
+});
+
+test('json.query describes itself the same way as text.find', async () => {
+  await withWorkspace(async root => {
+    await mkdir(join(root, 'config'), { recursive: true });
+    await writeFile(join(root, 'config/a.json'), '{"scripts":{"test":"node --test"}}', 'utf8');
+    await writeFile(join(root, 'config/b.json'), '{"scripts":{"test":"vitest"}}', 'utf8');
+
+    const found = await json.query({ root }, { files: 'config/*.json', path: '$.scripts.test' });
+    const searchScan = found.scan();
+
+    assert.equal(searchScan.source, 'json');
+    assert.equal(searchScan.inspected, 2);
+    assert.equal(found.scan({ source: 'policy' }).source, 'policy');
+  });
+});
+
+test('a search Scan is a value, so a Check can pass it straight to a result', async () => {
+  await withWorkspace(async root => {
+    await mkdir(join(root, 'src'), { recursive: true });
+    await writeFile(join(root, 'src/a.ts'), '// TODO: a\n', 'utf8');
+
+    const rules = defineRules({ noTodo: { id: 'source/no-todo', description: 'No TODO.' } });
+    const found = await text.find({ root }, { files: 'src/**/*.ts', find: 'TODO' });
+    const checkResult = result.fromBreaches(
+      found.scan(),
+      found.matches.map(match => breach(rules.noTodo, {
+        code: 'todo-found',
+        message: 'TODO comment found.',
+        location: match.location,
+      })),
+    );
+
+    assert.equal(checkResult.verdict, 'fail');
+    assert.equal(checkResult.scan.inspected, 1);
   });
 });


### PR DESCRIPTION
## Problem

Every text or JSON Check repeated the same six lines to build a `Scan`:

```ts
const startedAt = new Date().toISOString();
const found = await text.find(ctx, { files: 'src/**/*.ts', find: /\bTODO\b/g });
const scan = {
  source: 'text',
  startedAt,
  finishedAt: new Date().toISOString(),
  inspected: found.files.length,
} as const;
```

Four fixtures carried that block. `docs/composition.md` and the README showed it too.

The first line must come before the search. Nothing enforces that. Reorder them, or add a slow step between, and the recorded window is wrong. No test fails and no warning appears.

The README example did not even compile. It passed `found.scan`, and `TextSearch` has only `files` and `matches`:

```
readme-gate.ts(42,15): error TS2339: Property 'scan' does not exist on type 'TextSearch'.
```

That was not a random typo. The README documented the API somebody expected to exist.

## Fix

`text.find` and `json.query` now return a `scan()` function.

```ts
const found = await text.find(ctx, { files: 'src/**/*.ts', find: /\bTODO\b/g });

return result.fromBreaches(found.scan(), breaches);
```

Six lines become one. The README fix is two characters, `found.scan` to `found.scan()`.

`scan()` records the window of the search itself, so the caller cannot place `startedAt` in the wrong order. Defaults are `source: 'text'` or `'json'`, and `inspected: files.length`.

Both defaults stay overridable:

```ts
found.scan({ source: 'todo-scan' })
found.scan({ startedAt })            // the Check began working before the search
```

`json.query` gets the same function. `JsonSearch` had the identical shape and the identical boilerplate, so adding it to only one would leave an inconsistent API.

One `scan()` describes one search. A Check with several searches must still build its own `Scan`, or `inspected` under-counts while `counting.supported` claims a reliable count. `docs/composition.md` states that in a new "Describing a search" section.

Adapters are untouched. They build a `Scan` from an external tool run, not from a search.

## Verification

`npm run check` exit 0. 131 tests, 131 pass, 0 fail. Up from 127.
`npm run verify:package` exit 0. 50 PASS, 0 FAIL.

Four new tests. Six mutations, each on one guard.

| Mutation | Tests killed |
|---|---|
| `inspected` no longer counts the files read | 3 |
| `startedAt` taken at `scan()` time, not at search time | 1 |
| The `source` override ignored | 2 |
| The `startedAt` override ignored | 1 |
| `json.query` reports itself as a text search | 1 |
| `finishedAt` taken at `scan()` time, not at search time | 1 |

The window mutation first left the suite green. The test compared `startedAt` only against a lower bound. It now waits 20ms before calling `scan()` and asserts both bounds, so a window taken at `scan()` time fails.

Every TypeScript block in `README.md`, `docs/composition.md`, `docs/adapters.md`, and `docs/legacy-modernization.md` was extracted and type-checked. 51 blocks. No semantic error. The remaining errors are `TS1005`, `TS1109`, `TS1128`, and `TS1434`, all from blocks that are deliberate fragments.