### PR TITLE
Reject unknown options instead of ignoring them

### DIFF
--- a/packages/redproof/src/composition/config.ts
+++ b/packages/redproof/src/composition/config.ts
@@ -1,3 +1,4 @@
+import { rejectUnknownKeys, type NoUnknownKeys } from './options.ts';
 export type InPlaceExecutionConfig = {
   readonly mode: 'in-place';
 };
@@ -27,11 +28,19 @@ export type ResolvedRedproofConfig = {
   readonly execution: ResolvedExecutionConfig;
 };
 
-export function defineConfig<const C extends RedproofConfig>(config: C): C {
-  return config;
+export function defineConfig<const C extends RedproofConfig>(
+  config: C & NoUnknownKeys<C, RedproofConfig>,
+): C {
+  return config as C;
 }
 
+const CONFIG_KEYS = ['root', 'gatesRoot', 'refusalExit', 'execution'] as const;
+const EXECUTION_KEYS = ['mode', 'maxAtOnce'] as const;
+
 export function resolveConfig(config: RedproofConfig): ResolvedRedproofConfig {
+  rejectUnknownKeys(config, CONFIG_KEYS, 'config');
+  if (config.execution) rejectUnknownKeys(config.execution, EXECUTION_KEYS, 'execution');
+
   const gatesRoot = config.gatesRoot ?? 'gates/**/*.ts';
 
   const execution = config.execution ?? { mode: 'copies' as const };

--- a/packages/redproof/src/composition/options.ts
+++ b/packages/redproof/src/composition/options.ts
@@ -1,0 +1,33 @@
+/**
+ * Reject option names that are not part of `Shape`.
+ *
+ * A function written as `f<const O extends Shape>(options: O)` infers `O` from
+ * the object literal, so TypeScript checks the inferred type against `Shape`
+ * instead of checking the literal. An unknown option is then accepted and
+ * silently ignored at run time. Intersecting the parameter with this type
+ * gives every extra key the type `never`, so the literal is rejected.
+ */
+export type NoUnknownKeys<T, Shape> = {
+  readonly [K in Exclude<keyof T, keyof Shape>]: never;
+};
+
+/**
+ * Reject option names that are not in `allowed`.
+ *
+ * `NoUnknownKeys` guards the compiler. This guards the run time, which matters
+ * because Redproof strips types and never checks them when it loads a project.
+ */
+export function rejectUnknownKeys(
+  value: object,
+  allowed: readonly string[],
+  where: string,
+): void {
+  const unknown = Object.keys(value).filter(key => !allowed.includes(key));
+  if (unknown.length === 0) return;
+
+  throw new Error(
+    `Unknown ${where} ${unknown.length === 1 ? 'option' : 'options'}: `
+    + `${unknown.map(key => JSON.stringify(key)).join(', ')}. `
+    + `Known options: ${allowed.join(', ')}.`,
+  );
+}

--- a/packages/redproof/src/index.ts
+++ b/packages/redproof/src/index.ts
@@ -12,6 +12,7 @@ export * from './composition/adapter.ts';
 export * from './composition/gate.ts';
 export * from './composition/proof.ts';
 export * from './composition/config.ts';
+export * from './composition/options.ts';
 export * from './composition/inspect.ts';
 export * from './composition/mutation.ts';
 

--- a/packages/stryker/src/index.ts
+++ b/packages/stryker/src/index.ts
@@ -6,6 +6,8 @@ import {
   result,
   type Adapter,
   type Breach,
+  rejectUnknownKeys,
+  type NoUnknownKeys,
   type Rule,
   type RuleCatalog,
   type RuleRefOfCatalog,
@@ -65,9 +67,13 @@ function withoutTestRunnerEnv<T>(action: () => Promise<T>): Promise<T> {
   });
 }
 
+const STRYKER_RULE_NAMES = ['mutantsDetected', 'mutationScore'] as const;
+
 export function stryker<const O extends StrykerRuleOptions>(
-  options: StrykerAdapterOptions<O>,
+  options: StrykerAdapterOptions<O> & { readonly rules: NoUnknownKeys<O, StrykerRuleOptions> },
 ): Adapter<StrykerRuleCatalog<O>> {
+  rejectUnknownKeys(options.rules, STRYKER_RULE_NAMES, 'Stryker rule');
+
   if (!options.rules.mutantsDetected && !options.rules.mutationScore) {
     throw new Error('Stryker adapter requires at least one Redproof rule.');
   }

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -8,6 +8,8 @@ import {
   result,
   type Adapter,
   type Location,
+  rejectUnknownKeys,
+  type NoUnknownKeys,
   type Rule,
   type RuleRefOfCatalog,
 } from 'redproof';
@@ -61,9 +63,13 @@ function normalizeRun(root: string, run: TestRun): TestRun {
   };
 }
 
+const TEST_RULE_NAMES = ['testsPass', 'noSkippedTests', 'noTodoTests'] as const;
+
 export function testing<const O extends TestRuleOptions>(
-  options: TestingAdapterOptions<O>,
+  options: TestingAdapterOptions<O> & { readonly rules: NoUnknownKeys<O, TestRuleOptions> },
 ): Adapter<TestRuleCatalog<O>> {
+  rejectUnknownKeys(options.rules, TEST_RULE_NAMES, 'testing rule');
+
   if (!options.rules.testsPass && !options.rules.noSkippedTests && !options.rules.noTodoTests) {
     throw new Error('Testing adapter requires at least one Redproof rule.');
   }
@@ -216,7 +222,7 @@ export type VitestAdapterOptions<O extends TestRuleOptions> = {
 };
 
 export function vitest<const O extends TestRuleOptions>(
-  options: VitestAdapterOptions<O>,
+  options: VitestAdapterOptions<O> & { readonly rules: NoUnknownKeys<O, TestRuleOptions> },
 ): Adapter<TestRuleCatalog<O>> {
   return testing({
     runner: command({

--- a/tests/adapters/stryker.test.ts
+++ b/tests/adapters/stryker.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { defineRule } from 'redproof';
+import { stryker } from '@redproof/stryker';
 import {
   mutationMetrics,
   mutationScoreBreach,
@@ -108,4 +109,11 @@ test('mutation score is unavailable when there are no valid mutants', () => {
     mutant('2', 'RuntimeError'),
   ]);
   assert.equal(metrics.score, null);
+});
+
+test('the Stryker adapter rejects a rule name it does not know', () => {
+  assert.throws(
+    () => stryker({ rules: { mutantsDetected: true, mutantsKilled: true } as never }),
+    /Unknown Stryker rule option: "mutantsKilled"\. Known options: mutantsDetected, mutationScore\./,
+  );
 });

--- a/tests/adapters/testing.test.ts
+++ b/tests/adapters/testing.test.ts
@@ -210,3 +210,14 @@ test('testing adapter refuses an unexplained non-zero exit even when an empty re
     assert.match(result.why.detail ?? '', /exit code: 5/);
   });
 });
+
+test('the testing adapter rejects a rule name it does not know', () => {
+  assert.throws(
+    () => testing({
+      runner: { kind: 'test', async run() { return { exitCode: 0, reportFile: 'x' }; } } as never,
+      report: report.junitXml(),
+      rules: { testsPass: true, noPurpleTests: true } as never,
+    }),
+    /Unknown testing rule option: "noPurpleTests"\. Known options: testsPass, noSkippedTests, noTodoTests\./,
+  );
+});

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -202,3 +202,27 @@ test('exit-code policy is pure and REFUSE takes precedence over FAIL', () => {
   assert.equal(proofExitCode([{ ok: true }, { ok: true }]), 0);
   assert.equal(proofExitCode([{ ok: true }, { ok: false }]), 1);
 });
+
+test('config resolution rejects an unknown option instead of ignoring it', () => {
+  assert.throws(
+    () => resolveConfig({ root: '.', refuseExit: 2 } as never),
+    /Unknown config option: "refuseExit"\. Known options: root, gatesRoot, refusalExit, execution\./,
+  );
+
+  assert.throws(
+    () => resolveConfig({ execution: { mode: 'copies', maxAtOne: 4 } } as never),
+    /Unknown execution option: "maxAtOne"\. Known options: mode, maxAtOnce\./,
+  );
+
+  assert.throws(
+    () => resolveConfig({ refuseExit: 2, gateRoot: 'g' } as never),
+    /Unknown config options: "refuseExit", "gateRoot"/,
+  );
+
+  assert.doesNotThrow(() => resolveConfig({
+    root: '.',
+    gatesRoot: 'gates/**/*.ts',
+    refusalExit: 2,
+    execution: { mode: 'copies', maxAtOnce: 2 },
+  }));
+});

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -1,4 +1,4 @@
-import { vitest } from '@redproof/testing';
+import { testing, vitest, report, runner } from '@redproof/testing';
 import { dependencyCruiser } from '@redproof/dependency-cruiser';
 import { stryker } from '@redproof/stryker';
 import { command, commands } from 'redproof/command';
@@ -219,3 +219,28 @@ const passOnlyVitest = vitest({ rules: { testsPass: true } });
 passOnlyVitest.rules.testsPass;
 // @ts-expect-error noSkippedTests is not exposed when the rule was not selected.
 passOnlyVitest.rules.noSkippedTests;
+
+// An unknown option name must be rejected, not accepted and then ignored.
+
+defineConfig({ root: '.', gatesRoot: 'gates/**/*.ts', refusalExit: 2 });
+// @ts-expect-error refuseExit is not a config option.
+defineConfig({ root: '.', refuseExit: 2 });
+// Known limit: the guard reaches the top level only. A recursive version
+// breaks the ExecutionConfig union, so a nested unknown key is still accepted.
+defineConfig({ execution: { mode: 'copies', maxAtOne: 4 } });
+
+// @ts-expect-error noPurpleTests is not a testing Rule.
+vitest({ rules: { testsPass: true, noPurpleTests: true } });
+// @ts-expect-error noPurpleTests is not a testing Rule.
+vitest({ rules: { noPurpleTests: true } });
+
+testing({
+  runner: runner.command({ command: 'npm', args: () => ['test'] }),
+  report: report.junitXml(),
+  // @ts-expect-error noPurpleTests is not a testing Rule.
+  rules: { testsPass: true, noPurpleTests: true },
+});
+
+stryker({ rules: { mutantsDetected: true } });
+// @ts-expect-error mutantsKilled is not a Stryker Rule.
+stryker({ rules: { mutantsDetected: true, mutantsKilled: true } });


### PR DESCRIPTION
## Problem

Four public functions accepted an option name that does not exist, then did nothing with it.

```ts
defineConfig({ root: '.', gatesRoot: 'g/**/*.ts', refuseExit: 2 });
vitest({ rules: { testsPass: true, noPurpleTests: true } });
```

Both compile. `refuseExit` is not a config option. `noPurpleTests` is not a Rule. Neither has any effect, and nothing says so.

`testing` and `stryker` behave the same way.

The cause is one signature shape. Each is written as `f<const O extends Shape>(options: O)`. TypeScript infers `O` from the object literal, then checks the inferred type against `Shape`. Excess property checking never runs on the literal, because the literal is what `O` was inferred from.

A probe of all 17 functions taking a `const` generic shows the exact boundary. An unknown key alone is rejected. An unknown key beside a valid key, inside a naked generic, is accepted. Wrapper types such as `CommandCheckOptions<R>` are not affected, so `command` and `commands` already reject unknown options.

## Fix

Guard both sides, because each alone leaves a hole.

`NoUnknownKeys<T, Shape>` gives every key of `T` that is not in `Shape` the type `never`, so the compiler rejects the literal.

```ts
export function defineConfig<const C extends RedproofConfig>(
  config: C & NoUnknownKeys<C, RedproofConfig>,
): C
```

That alone is not enough. Redproof loads a config with `--experimental-strip-types`, which removes types without checking them. A user who never runs `tsc` still gets the silent ignore. So `rejectUnknownKeys` throws at run time:

```
Error: Unknown config option: "refuseExit". Known options: root, gatesRoot, refusalExit, execution.
```

The run-time guard also covers `config.execution`, which the type guard cannot reach. A recursive `NoUnknownKeys` was tried and rejected: it breaks the `ExecutionConfig` union and makes valid calls fail. `tests/types.ts` records that limit where the next reader will look.

Applied to `defineConfig`, `testing`, `vitest` and `stryker`.

## Verification

`npm run check` exit 0. 134 tests, 134 pass, 0 fail. Up from 131.
`npm run verify:package` exit 0. 50 PASS, 0 FAIL.

Eight guards, eight mutations, each removing one guard.

| Mutation | Result |
|---|---|
| `defineConfig` type guard removed | `tests/types.ts(226,1): TS2578: Unused '@ts-expect-error' directive.` |
| `vitest` type guard removed | `tests/types.ts(232,1): TS2578` |
| `testing` type guard removed | `tests/types.ts(240,3): TS2578` |
| `stryker` type guard removed | `tests/types.ts(245,1): TS2578` |
| config run-time guard removed | 1 test red |
| execution run-time guard removed | 1 test red |
| testing rule run-time guard removed | 1 test red |
| Stryker rule run-time guard removed | 1 test red |

Green returned after each restore.

The type-level tests use `@ts-expect-error`. Removing a guard makes the directive unused, which is itself a compile error, so a missing rejection fails `npm run typecheck`.

The run-time guard was also driven through the real CLI against a fixture config:

```
Error: Unknown config option: "refuseExit". Known options: root, gatesRoot, refusalExit, execution.
Error: Unknown execution option: "maxAtOne". Known options: mode, maxAtOnce.
```