### PR TITLE
Add the redproof skill

### DIFF
--- a/skills/redproof/SKILL.md
+++ b/skills/redproof/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: redproof
+description: Proves that a check can fail before anyone trusts it. Breaks the smallest thing the check guards, confirms red for the right rule, restores, and confirms green. Holds the rule for when a proof is owed and, far more often, when it is not. Use when a guard was written and passed on its first run. Use when you changed what a check looks at, such as a glob, an ignore list, a rule selection, a severity, a threshold, or a timeout. Use when you edited an expected value to match your own output. Use before you rely on or cite a check you have never seen go red. Use when a check can only print success. Use when the user asks for a red-proof. Not for feature work, refactors, renames, documentation, or a suite run the user asked for.
+domain: engineering
+role: sensor
+stage: verify
+---
+
+# redproof — a green run is not evidence the check works
+
+A check went green. That means one of two things. The code is correct, or the
+check is blind. The two look identical from the outside.
+
+A **red-proof** removes the doubt. You break the smallest thing the check
+guards. You confirm the check goes red for the right rule. You restore, and you
+confirm green again.
+
+This matters most where failure is quiet. A check that can only print success
+looks exactly like a check that works.
+
+## Is a proof owed?
+
+The description above is wide on purpose, so this skill loads often. Most loads
+end here with no proof. **This section is the authority, not the description.**
+
+**Default: no.** A real workday is ordinary work. Do not offer a proof every
+turn.
+
+A proof is owed only when both are true.
+
+1. **The guard is unproven to you.** You have never seen it go red. You wrote it
+   and it passed on its first run. Or you changed it, weakened it, or are about
+   to rely on it or cite it.
+2. **A blind pass would be quiet.** If the check stopped detecting tomorrow, no
+   other signal would say so.
+
+One "no" ends it. Do the work and move on.
+
+There are three outcomes, not two. Say which one you reached.
+
+```text
+NO PROOF             one answer was no. Say nothing about red-proofs.
+PROOF                both were yes. Run the loop.
+OWED, NOT PROVED     both were yes, and no safe break exists.
+```
+
+For a borderline case, read [`verdicts.md`](verdicts.md) first. It holds 33
+worked verdicts and answers most cases on sight.
+
+### Quiet or loud
+
+Question 2 decides most cases, so answer it first.
+
+A blind pass is **quiet** when the only evidence is the word "pass". These four
+shapes print success forever:
+
+- **The check never runs.** A glob matches no files. A path is wrong. A job
+  condition is false.
+- **The failure is swallowed.** A script ends with `|| true`. A job sets
+  `continue-on-error: true`. A `try` block catches the assertion error.
+- **The tool exits 0 when it cannot work.** A missing config file, zero input
+  files, or a parse error can all end in a success status.
+- **The check reads a stale report.** The report is from an earlier run. The
+  current run wrote nothing.
+
+A blind pass is **loud** when a person would see the fault within seconds. A
+compile error, a crash at start, a missing binary, or wrong output on screen.
+Loud faults need no proof. The world already tells you.
+
+Six more ways a check goes blind are in [`breaking.md`](breaking.md).
+
+### These count as touching the guard
+
+You did not edit the check, and the guard is still unproven. Treat all four as
+question 1 answered yes.
+
+- You **edited an expected value** to match your own new output.
+- You **changed what the check looks at**: a glob, an ignore list, a rule
+  selection, a severity, a threshold, or a timeout.
+- The check **passed unchanged before and after** your change, and you now say
+  it covers the new code.
+- You are **about to rely on or cite** a check you have never seen go red.
+
+This list is the one agents miss. A new check looks like detector work. A
+loosened old check does not.
+
+### Never prove these
+
+- Feature code, bug fixes, refactors, renames, formatting, documentation.
+- A suite run the user asked for. Report the result. Offer the proof in one
+  line. Do not perform it.
+- A test you already watched fail before you made it pass. The red already
+  happened.
+- A check that fails often in real use. The field has proved it.
+- A third-party engine. Prove your rule selection and your wiring. Do not prove
+  the vendor's parser.
+- Spikes, throwaway scripts, and code you will delete today.
+- A deleted file, unless it held a test the runner collected. Check that first.
+
+### Two cases that end the question early
+
+**The check already confessed.** Its own output says it inspected nothing.
+`Checked 0 links.` and exit 0 is not a case for a proof. It is the finding. Say
+the check is blind, and fix it. Do not run the loop.
+
+**No safe break exists.** Some guards cannot be broken cheaply. You would have
+to install a package with a known fault, edit a lock file, or touch a system
+outside the repository. Do not force it. The verdict is OWED, NOT PROVED. A
+stated limit is a real report.
+
+### Cost
+
+One proof costs a few minutes. Ten proofs cost an hour, and they edit files
+nobody asked you to touch. Prove the one check that carries the most weight.
+Name the checks you skipped, and stop.
+
+If the check takes more than about two minutes to run, ask the user first.
+
+## The loop
+
+Run these steps in order. Do not reorder them.
+
+1. **State the rule.** Write one sentence. What must be true?
+2. **Plan the restore.** Decide how you will undo the break, before you make it.
+3. **Choose the smallest break.** It must violate that one rule and nothing
+   else. See [`breaking.md`](breaking.md).
+4. **Break it.** Break the thing being checked. Never break the check.
+5. **Run the same check.** Same command, same arguments, same scope. A narrowed
+   check proves a different check.
+6. **Read the output.** Confirm red. Confirm the message names your rule.
+7. **Restore.**
+8. **Run the check again.** Confirm green.
+9. **Report the red and the green.**
+
+Step 6 is the step agents skip. A red for the wrong reason is not a proof.
+
+## Safety
+
+A break left behind is worse than no proof. These rules are not optional.
+
+- **Restore before you stop.** If you must abandon the loop, restore first, then
+  say so.
+- **One break at a time.**
+- **Check the file first.** Run `git status` on that path. Do not break a file
+  that holds work you cannot restore.
+- **Never commit or push while a break is planted.**
+- **Never break live things.** No production config, no secrets, no migration
+  that runs at start, no real payment, no real email.
+- **If the restore fails, stop.** Name the file. Tell the user. Do not continue.
+
+## When the check stays green
+
+The check is blind. That is the finding, and the exercise worked.
+
+Do not make the break bigger to force a red. That proves nothing.
+
+Check three things, in order. Did the check really run? Was the break inside the
+scope the check reads? Did something swallow the failure?
+
+Then report the gap. Say which rule is now unguarded. Fix the check only if the
+user asked for a fix.
+
+## Report
+
+Show both results. "It passes" is not a report here.
+
+```text
+Red-proof: <the rule, in one sentence>
+  break     <file:line, and what changed>
+  red       <the output line that named the rule>
+  restore   <how, and confirmed clean>
+  green     <the check passing again>
+```
+
+When the verdict was OWED, NOT PROVED, report that instead.
+
+```text
+Owed, not proved: <the rule>
+  why not   <the reason no safe break exists>
+```
+
+Then say what you did not prove, and why. A skipped proof is a decision, not an
+omission.
+
+## Make a proof repeat
+
+A manual proof is true once, for the code you had that day. The check can go
+blind next month and the old proof will not notice.
+
+Redproof is the library in this repository. It stores the break next to the
+check and repeats the loop on every commit. Use it when the guard is permanent.
+Do not use it for a one-time proof.
+
+Read [`../../README.md`](../../README.md) and [`../../docs/`](../../docs/). Those
+files ship with the code, so they cannot go stale.

--- a/skills/redproof/breaking.md
+++ b/skills/redproof/breaking.md
@@ -1,0 +1,147 @@
+# Breaking well
+
+How to choose a break that proves the right thing. Read this at step 3 of the
+loop.
+
+- [Six more ways a check goes blind](#six-more-ways-a-check-goes-blind)
+- [Ask the check what it inspected](#ask-the-check-what-it-inspected)
+- [The smallest break, per guard](#the-smallest-break-per-guard)
+- [The scope-change trap](#the-scope-change-trap)
+- [Reading the red](#reading-the-red)
+- [Two worked proofs](#two-worked-proofs)
+
+## Six more ways a check goes blind
+
+`SKILL.md` names the four quiet shapes. These six are the rest.
+
+1. **The assertion is empty.** The test asserts that a value is defined, or that
+   a list has a length, and nothing more.
+2. **The test is off.** Someone wrote `.skip`, `xit`, or `@Ignore`. Or an
+   `.only` elsewhere in the file hides the rest.
+3. **The rule is off.** A severity moved to `warn`. A rule left the config. A
+   file joined the ignore list.
+4. **A mock answers the question.** The test asserts on the value the mock
+   supplied. The real code never decides anything.
+5. **The check runs on the wrong build.** The artifact under test does not
+   contain the change. A stale `dist` directory is the common case.
+6. **A snapshot was updated blind.** The recorded output now matches the new
+   wrong behaviour.
+
+## Ask the check what it inspected
+
+Before you plant a break, ask whether the check looked at anything. This is
+faster than a proof, and it answers the most common blindness on its own.
+
+A Redproof Check reports the count directly:
+
+```bash
+redproof check --reporter=json --outputFile=out.json
+```
+
+Every Check result carries a `scan` with an `inspected` count. The ESLint
+adapter sets it to the number of linted files, at
+`packages/eslint/src/index.ts`. An `inspected` value of zero is the answer. The
+check is blind, and no break is needed.
+
+Other tools expose the same thing under other names. A test count, a file count,
+a duration. When the number is zero, stop and fix the check.
+
+## The smallest break, per guard
+
+**Unit or integration test.** Break the code under test. Do not break the test.
+Change one returned value, one boundary, or one branch. Expect one named test to
+fail.
+
+**Assertion inside product code.** Feed the input the assertion rejects. Do not
+delete the assertion. A deleted assertion proves the assertion exists, not that
+it fires.
+
+**Lint rule.** Add one line that the rule forbids. Put it in a file the rule
+covers. Read the ignore list first.
+
+**Type check.** Assign a wrong type at one call site. Do not use a cast and do
+not use `any`. Both hide the error you want to see.
+
+**Architecture or dependency rule.** Add one forbidden import. Keep the code
+valid so it still compiles. A compile error would mask the real result.
+
+**Schema or contract check.** Send one payload with one field wrong. Missing,
+wrong type, or out of range. Change one field, not three.
+
+**CI step.** Break the thing the step guards, on a branch. Watch the job go red.
+Do not edit the workflow file to force a failure. That proves the workflow runs.
+It does not prove the guard detects.
+
+**Alert or health check.** Make the watched dependency unavailable, in a test
+environment. Confirm the alert fires and names the right condition.
+
+**Mutation score gate.** Weaken or delete one test. Do not touch the source.
+Confirm the score drops below the minimum.
+
+**Characterization suite.** Change the legacy output the suite records. Confirm
+the named test fails. Then prove the skip rule too. Turn one test into a skipped
+test and confirm the gate notices. A skipped test is the most common way a
+safety net stops working.
+
+**Coverage threshold.** Delete a test that covers a branch. Confirm the check
+fails. Do not lower the threshold.
+
+## The scope-change trap
+
+You changed a glob, a path, or an ignore list. The break must go where **only
+the new scope reaches**.
+
+A break inside both the old scope and the new scope goes red either way. That
+red proves the rule works. It proves nothing about the change you made.
+
+A scope change has two halves, so prove both. Prove them one at a time.
+
+1. **The new scope is watched.** Plant the break at a path only the new scope
+   covers. Expect red. Restore.
+2. **The old scope was dropped on purpose.** Plant the break at the old path.
+   Expect green. Restore.
+
+The second pass turns an assumption into a decision.
+
+## Reading the red
+
+- The message must name your rule, your file, and your break.
+- One failure is strong evidence. Forty failures are weak evidence. Aim for one.
+- A compile error is not a proof. Choose a break that still compiles.
+- If the check failed before it reached your break, the proof is void. Fix the
+  break and run again.
+- If the check went red for a different rule, the proof is void. The rule you
+  targeted is still unproven.
+- A REFUSE is not a red. It means the Check could not decide. Treat it as an
+  unknown, never as a pass.
+
+## Two worked proofs
+
+### A new lint rule
+
+The rule: source files must not call `console.log`.
+
+```text
+break     src/order.ts:12, added `console.log('x');`
+red       src/order.ts:12:1  error  Unexpected console statement  no-console
+restore   removed line 12; git status clean
+green     0 problems
+```
+
+The red names `no-console` and names the file. That is a proof.
+
+If the red had said `no-unused-vars`, the proof would be void.
+
+### An architecture rule
+
+The rule: domain code must not import infrastructure code.
+
+```text
+break     src/domain/order.ts, added `import '../infrastructure/db.js';`
+red       error domain-no-infrastructure: src/domain/order.ts -> src/infrastructure/db.js
+restore   removed the import; git status clean
+green     no dependency violations found
+```
+
+The import is valid code, so the file still compiles. The rule engine, not the
+compiler, produced the red.

--- a/skills/redproof/verdicts.md
+++ b/skills/redproof/verdicts.md
@@ -1,0 +1,84 @@
+# Worked verdicts
+
+Calibration for the two questions in `SKILL.md`. Read this when a case feels
+borderline.
+
+- [The default answer](#the-default-answer)
+- [Worked verdicts](#worked-verdicts)
+- [Budget rules](#budget-rules)
+- [Stop and ask first](#stop-and-ask-first)
+
+## The default answer
+
+The default answer is no.
+
+An agent that red-proofs everything is useless. It is slow. It edits code it
+should not touch. It turns a five-minute task into an hour.
+
+The two questions form an AND gate.
+
+```text
+Q1  the guard is unproven to you
+Q2  a blind pass would be quiet
+```
+
+Most work fails at Q1. Of the work that passes Q1, much fails at Q2.
+
+## Worked verdicts
+
+| Situation | Owed? | Why |
+| --- | --- | --- |
+| "Run the tests." | No | Never-prove list. Report the result. Offer the proof in one line. |
+| "Fix this date format bug." | No | Q1. Feature code is not a guard. |
+| You added a regression test first and watched it fail. | No | The red already happened. Do not repeat it. |
+| You added a regression test after the fix and it passed at once. | Yes | Q1 yes, and a weak test prints green forever. |
+| You added a CLI flag and one unit test for it. The test passes. | No | Q2. If the flag broke, the terminal would show wrong output. That is loud. |
+| You added a new lint rule to the config. | Yes | A rule that matches no file passes forever and looks healthy. |
+| You changed a lint rule severity from error to warn. | Yes | Q1 by the touching list. The gate may now pass on real findings. |
+| You bumped the linter version. | No | Q1. You changed a dependency, not a guard. |
+| You wrote a test that mocks the function it is testing. | Yes | The classic blind test. Break the real function and watch. |
+| You added an assertion to an existing passing test. | Yes | Q2. A weak assertion is invisible. Break the value it reads. |
+| You renamed a test file. | No | Q1. The guard did not change. |
+| You deleted a file nothing imports. | No | Q1, but confirm first that it was not a test the runner collected. |
+| You added a CI step that runs a script. | Yes | Q2. A script that always exits 0 looks exactly like a healthy step. |
+| You added a step with `continue-on-error: true`. | Yes | It can never fail the build. Confirm the user wants that. |
+| You added a CI job that runs a vulnerability audit. | Owed, cannot prove | Q1 and Q2 both yes. The only break is a package with a known fault, which edits the lock file. State the limit. |
+| You raised a flaky test's timeout from 5s to 10s. | Owed, often cannot prove | Q1 by the touching list. A slow regression now hides. You cannot break "slow" cheaply. State the limit. |
+| You added a health check or an alarm. | Yes | Q2. An alarm with no data source is silent forever. |
+| You added an input validation rule. | Yes | Q2. Send the bad input. Confirm it is rejected. |
+| You added an architecture or dependency rule. | Yes | Q2. A rule with a wrong path glob matches nothing. |
+| You changed a rule's file glob for a workspace move. | Yes | Q1 by the touching list. Read the scope-change trap in `breaking.md`. |
+| You added a coverage threshold. | Yes | Q2. Confirm the number can drop below the line. |
+| You raised the coverage threshold from 80 to 85. | No | The gate already proved it can fail. |
+| You edited a test's expected value to match your new output. | Yes | Q1 by the touching list. The test may now record the wrong answer. |
+| You added a null guard. The existing test passed before and after. | Yes | Q1 by the touching list. A test that cannot tell the two states apart does not cover the case. |
+| A script printed `Checked 0 items` and exited 0. | No proof | The check already confessed. Say it is blind. Fix it. |
+| You are reading someone else's test to understand it. | No | Q1. You claim nothing about it. |
+| You are about to rely on a teammate's gate you never saw go red. | Yes | Q1 by the touching list. A PASS is the only evidence on offer. |
+| You are about to say "this is covered by tests". | Yes | That sentence is the claim. Prove it or soften it. |
+| You are about to say "the fix is verified". | Yes | Same. Name what you actually ran instead. |
+| You are about to say a gate "protects" or "prevents" something. | Yes | A claim about what a gate covers. Prove it, or name what you actually ran. |
+| A Redproof Proof already targets this Rule. | No | The proof runs on every commit. Run it, do not repeat it by hand. |
+| You reformatted a test file. | No | Q1. No behaviour changed. |
+| The break would touch production or a shared database. | No | Never. Say what you cannot prove and why. |
+
+## Budget rules
+
+- One red-proof per guard. Not one per assertion.
+- Prove the claim that matters most. Skip the rest and name what you skipped.
+- Time cap: if the break plus the restore takes more than a few minutes, ask.
+- Batch cap: if a change adds more than three guards, prove the two highest risk
+  ones.
+- Never red-proof while the baseline is red. Get it green first, or the proof
+  means nothing.
+- A generated or copied check counts as new. You did not watch it fail.
+- Prove a guard after a large refactor is green, not during it.
+
+## Stop and ask first
+
+- The break would touch a file outside your current change.
+- The break would touch a system you do not control.
+- The working tree is dirty in the file you must break.
+- You cannot describe the exact restore.
+- The check is slow and you would run it three times.
+- The user asked for speed. Offer in one line, do not perform.


### PR DESCRIPTION
## Problem

This repository ships a library that proves a check can fail. It ships no
guidance on when to use that discipline, so an agent working here has two ways
to get it wrong.

It can under-use the discipline. A new gate goes green on its first run, nobody
ever sees it red, and a blind gate looks exactly like a working one.

It can over-use the discipline. An agent that red-proofs every unit test edits
files nobody asked it to touch and turns a five-minute task into an hour.

The second failure is the one that makes a skill unusable. A test measured it.
Five candidate skills were written and each was given the same working day of
17 items. Item 1 was a new CLI flag with one unit test. Four of the five
candidates demanded a full break-and-restore cycle for it.

## Fix

`skills/redproof/` holds a skill in three files.

`SKILL.md` is the decision layer, 195 lines. A proof is owed only when both of
these are true:

1. The guard is unproven to you. You have never seen it go red.
2. A blind pass would be quiet. No other signal would say the check went blind.

Question 2 is what stops the over-use. A broken `--quiet` flag prints wrong
output on the terminal. That fault is loud, so no proof is needed.

The decision layer also holds three things the test showed were missing:

- A list of edits that count as touching a guard even when the check was not
  edited. An expected value changed to match your own output. A glob, a
  threshold, a severity, or a timeout changed. A check that passed unchanged
  before and after your change.
- A branch for a check that already confessed. A script that prints
  `Checked 0 links.` and exits 0 is the finding, not a case for a proof.
- A third verdict, `OWED, NOT PROVED`, for a guard with no safe break. A
  vulnerability audit cannot be broken without editing a lock file.

`breaking.md` holds the smallest break for each kind of guard, the six rarer
ways a check goes blind, and the scope-change trap. `verdicts.md` holds 33
worked verdicts.

The library is not copied into the skill. `SKILL.md` points at `README.md` and
`docs/`, which ship with the code and cannot go stale.

The frontmatter description is wide, so the skill loads often. One line in the
body says the decision section is the authority. Every trigger phrase in the
description also appears in the body, so the two cannot drift apart.

## Verification

A fresh agent ran the same 17-item working day against this skill and produced
no unclear verdicts. The five candidates each produced two or three.

The three items that separate this version:

```
W1   new CLI flag, one passing unit test    NO PROOF          4 of 5 candidates said PROOF
W6   script prints "Checked 0 links."       fix it, no proof  5 of 5 candidates ran the loop
W12  null guard, test passed before/after   PROOF             3 of 5 candidates said NO PROOF
```

The rule that keeps the description and the body in agreement was red-proofed.
A trigger was removed from the body and the description was left alone.

RED:

```
DRIFT — in the description but not in the body:
  - a glob, an ignore list, a rule selection, a severity, a threshold, or a timeout
exit=1
```

Restored, then GREEN:

```
OK — every description trigger appears in the body.
exit=0
```

That checker holds a hand-written phrase list. It catches an edit to the body.
It does not catch a new trigger added to the description.

All four relative pointers resolve: `breaking.md`, `verdicts.md`,
`../../README.md`, `../../docs/`. The description is 732 characters, inside the
1024 budget.
