### PR TITLE
Support baselined dependency-cruiser self-checks

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -153,6 +153,7 @@ import { defineGate, defineProofs, mutate, proof } from 'redproof';
 
 const adapter = dependencyCruiser({
   configFile: '.dependency-cruiser.cjs',
+  knownViolationsFile: '.dependency-cruiser-known-violations.json',
   files: ['src'],
   rules: {
     domainNoInfrastructure: 'domain-no-infrastructure',
@@ -181,6 +182,9 @@ export default gate;
 ```
 
 One dependency-cruiser run can report breaches across several selected Rules.
+When `knownViolationsFile` is set, the adapter ignores matching committed baseline
+violations while still reporting new violations. The adapter disables dependency-
+cruiser caching so RED mutations cannot reuse a stale pre-mutation result.
 
 ## Stryker
 

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -186,6 +186,11 @@ When `knownViolationsFile` is set, the adapter ignores matching committed baseli
 violations while still reporting new violations. The adapter disables dependency-
 cruiser caching so RED mutations cannot reuse a stale pre-mutation result.
 
+A baseline makes the Gate quieter on purpose. That is a weakening, so keep it
+honest. A baseline that grows every time somebody adds debt guards nothing, and
+it still reports PASS. Keep a RED proof that plants a new violation, and confirm
+the Gate still fails. A malformed baseline file is refused, not ignored.
+
 ## Stryker
 
 Package:

--- a/packages/dependency-cruiser/README.md
+++ b/packages/dependency-cruiser/README.md
@@ -46,6 +46,11 @@ baseline. Matching known violations are ignored; new violations still breach
 their selected Redproof Rules. Checks run without dependency-cruiser caching so
 proof mutations cannot reuse stale architecture results.
 
+A baseline weakens the Gate on purpose. Keep a RED proof that plants a new
+violation, so the Gate is known to still fail. A baseline that grows with every
+new violation guards nothing and still reports PASS. A baseline file that is not
+a JSON array produces REFUSE, never a pass.
+
 Then run:
 
 ```bash

--- a/packages/dependency-cruiser/README.md
+++ b/packages/dependency-cruiser/README.md
@@ -20,6 +20,7 @@ import { defineGate, defineProofs, mutate, proof } from 'redproof';
 
 const adapter = dependencyCruiser({
   configFile: '.dependency-cruiser.cjs',
+  knownViolationsFile: '.dependency-cruiser-known-violations.json',
   files: ['src'],
   rules: {
     domainNoInfrastructure: 'domain-no-infrastructure',
@@ -39,6 +40,11 @@ export const proofs = defineProofs(gate, [
 
 export default gate;
 ```
+
+Set `knownViolationsFile` when the project maintains a dependency-cruiser
+baseline. Matching known violations are ignored; new violations still breach
+their selected Redproof Rules. Checks run without dependency-cruiser caching so
+proof mutations cannot reuse stale architecture results.
 
 Then run:
 

--- a/packages/dependency-cruiser/src/index.ts
+++ b/packages/dependency-cruiser/src/index.ts
@@ -1,6 +1,5 @@
-import { cruise } from 'dependency-cruiser';
-import extractDepcruiseConfig from 'dependency-cruiser/config-utl/extract-depcruise-config';
-import extractDepcruiseOptions from 'dependency-cruiser/config-utl/extract-depcruise-options';
+import { readFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
 import { resolve } from 'node:path';
 import {
   counting,
@@ -24,7 +23,29 @@ type DependencyCruiserRuleCatalog<M extends DependencyCruiserRuleInput> = {
 export type DependencyCruiserAdapterOptions<M extends DependencyCruiserRuleInput> = {
   readonly files?: readonly string[];
   readonly configFile?: string;
+  readonly knownViolationsFile?: string;
   readonly rules: M;
+};
+
+type DependencyCruiserModules = {
+  readonly cruise: typeof import('dependency-cruiser').cruise;
+  readonly extractConfig: typeof import('dependency-cruiser/config-utl/extract-depcruise-config').default;
+  readonly extractOptions: typeof import('dependency-cruiser/config-utl/extract-depcruise-options').default;
+};
+
+type DependencyCruiserOptions = NonNullable<
+  Parameters<DependencyCruiserModules['cruise']>[1]
+>;
+type KnownViolations = NonNullable<DependencyCruiserOptions['knownViolations']>;
+
+type PackageExport = string | {
+  readonly import?: string;
+  readonly default?: string;
+};
+
+type PackageManifest = {
+  readonly name?: string;
+  readonly exports?: Readonly<Record<string, PackageExport>>;
 };
 
 type DependencyCruiserConfig = {
@@ -73,6 +94,50 @@ function withCwd<T>(root: string, action: () => Promise<T>): Promise<T> {
   return action().finally(() => process.chdir(before));
 }
 
+function selfExport(manifest: PackageManifest, subpath: string): string {
+  const exported = manifest.exports?.[subpath];
+  const target = typeof exported === 'string'
+    ? exported
+    : exported?.import ?? exported?.default;
+  if (!target) {
+    throw new Error(`dependency-cruiser does not export ${subpath}.`);
+  }
+  return target;
+}
+
+async function loadDependencyCruiser(root: string): Promise<DependencyCruiserModules> {
+  const manifest = JSON.parse(
+    await readFile(resolve(root, 'package.json'), 'utf8'),
+  ) as PackageManifest;
+
+  if (manifest.name === 'dependency-cruiser') {
+    const loadSelf = (subpath: string) => import(pathToFileURL(
+      resolve(root, selfExport(manifest, subpath)),
+    ).href);
+    const [main, config, options] = await Promise.all([
+      loadSelf('.'),
+      loadSelf('./config-utl/extract-depcruise-config'),
+      loadSelf('./config-utl/extract-depcruise-options'),
+    ]);
+    return {
+      cruise: main.cruise as DependencyCruiserModules['cruise'],
+      extractConfig: config.default as DependencyCruiserModules['extractConfig'],
+      extractOptions: options.default as DependencyCruiserModules['extractOptions'],
+    };
+  }
+
+  const [main, config, options] = await Promise.all([
+    import('dependency-cruiser'),
+    import('dependency-cruiser/config-utl/extract-depcruise-config'),
+    import('dependency-cruiser/config-utl/extract-depcruise-options'),
+  ]);
+  return {
+    cruise: main.cruise,
+    extractConfig: config.default,
+    extractOptions: options.default,
+  };
+}
+
 export function dependencyCruiser<const M extends DependencyCruiserRuleInput>(
   options: DependencyCruiserAdapterOptions<M>,
 ): Adapter<DependencyCruiserRuleCatalog<M>> {
@@ -109,8 +174,9 @@ export function dependencyCruiser<const M extends DependencyCruiserRuleInput>(
 
         try {
           return await withCwd(ctx.root, async () => {
+            const dependencyCruiser = await loadDependencyCruiser(ctx.root);
             const configPath = resolve(ctx.root, configFile);
-            const config = await extractDepcruiseConfig(configPath) as DependencyCruiserConfig;
+            const config = await dependencyCruiser.extractConfig(configPath) as DependencyCruiserConfig;
             const available = configuredRuleNames(config);
             const missing = Object.values(options.rules).filter(name => !available.has(name));
 
@@ -131,11 +197,18 @@ export function dependencyCruiser<const M extends DependencyCruiserRuleInput>(
               );
             }
 
-            const cruiseOptions = await extractDepcruiseOptions(configPath);
-            const cruiseResult = await cruise(
+            const cruiseOptions = await dependencyCruiser.extractOptions(configPath);
+            const knownViolations = options.knownViolationsFile
+              ? JSON.parse(
+                await readFile(resolve(ctx.root, options.knownViolationsFile), 'utf8'),
+              ) as KnownViolations
+              : undefined;
+            const cruiseResult = await dependencyCruiser.cruise(
               files,
               {
                 ...cruiseOptions,
+                cache: false,
+                ...(knownViolations ? { ignoreKnown: true, knownViolations } : {}),
                 outputType: 'json',
               },
             );

--- a/packages/dependency-cruiser/src/index.ts
+++ b/packages/dependency-cruiser/src/index.ts
@@ -105,12 +105,16 @@ function selfExport(manifest: PackageManifest, subpath: string): string {
   return target;
 }
 
-async function loadDependencyCruiser(root: string): Promise<DependencyCruiserModules> {
-  const manifest = JSON.parse(
-    await readFile(resolve(root, 'package.json'), 'utf8'),
-  ) as PackageManifest;
+async function selfManifest(root: string): Promise<PackageManifest | null> {
+  const manifest = await readFile(resolve(root, 'package.json'), 'utf8')
+    .then(text => JSON.parse(text) as PackageManifest, () => null);
+  return manifest?.name === 'dependency-cruiser' ? manifest : null;
+}
 
-  if (manifest.name === 'dependency-cruiser') {
+async function loadDependencyCruiser(root: string): Promise<DependencyCruiserModules> {
+  const manifest = await selfManifest(root);
+
+  if (manifest) {
     const loadSelf = (subpath: string) => import(pathToFileURL(
       resolve(root, selfExport(manifest, subpath)),
     ).href);
@@ -136,6 +140,25 @@ async function loadDependencyCruiser(root: string): Promise<DependencyCruiserMod
     extractConfig: config.default,
     extractOptions: options.default,
   };
+}
+
+async function readKnownViolations(path: string): Promise<KnownViolations | Error> {
+  const text = await readFile(path, 'utf8').catch(
+    (error: NodeJS.ErrnoException) => error,
+  );
+  if (text instanceof Error) return new Error(`Cannot read ${path}. ${text.message}`);
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (error) {
+    return new Error(`${path} is not valid JSON. ${(error as Error).message}`);
+  }
+
+  if (!Array.isArray(parsed)) {
+    return new Error(`${path} must hold a JSON array of known violations.`);
+  }
+  return parsed as KnownViolations;
 }
 
 export function dependencyCruiser<const M extends DependencyCruiserRuleInput>(
@@ -198,11 +221,27 @@ export function dependencyCruiser<const M extends DependencyCruiserRuleInput>(
             }
 
             const cruiseOptions = await dependencyCruiser.extractOptions(configPath);
-            const knownViolations = options.knownViolationsFile
-              ? JSON.parse(
-                await readFile(resolve(ctx.root, options.knownViolationsFile), 'utf8'),
-              ) as KnownViolations
+            const baselineFile = options.knownViolationsFile;
+            const knownViolations = baselineFile
+              ? await readKnownViolations(resolve(ctx.root, baselineFile))
               : undefined;
+
+            if (knownViolations instanceof Error) {
+              return result.refuse(
+                {
+                  source: 'dependency-cruiser',
+                  startedAt,
+                  finishedAt: now(),
+                  inspected: null,
+                },
+                {
+                  code: 'dependency-cruiser-known-violations-invalid',
+                  message: 'The known-violations baseline could not be read.',
+                  location: { file: baselineFile!, line: null, column: null },
+                  detail: knownViolations.message,
+                },
+              );
+            }
             const cruiseResult = await dependencyCruiser.cruise(
               files,
               {

--- a/tests/adapters/dependency-cruiser.test.ts
+++ b/tests/adapters/dependency-cruiser.test.ts
@@ -130,3 +130,85 @@ test('dependency-cruiser self-hosts with baseline violations and cache disabled'
     assert.equal(check.scan.inspected, 1);
   });
 });
+
+async function writeFakeDependencyCruiser(root: string, cruiseBody: string): Promise<void> {
+  await mkdir(join(root, 'config-utl'), { recursive: true });
+  await writeFile(join(root, 'package.json'), JSON.stringify({
+    name: 'dependency-cruiser',
+    type: 'module',
+    exports: {
+      '.': './main.mjs',
+      './config-utl/extract-depcruise-config': './config-utl/config.mjs',
+      './config-utl/extract-depcruise-options': './config-utl/options.mjs',
+    },
+  }), 'utf8');
+  await writeFile(join(root, 'main.mjs'), cruiseBody, 'utf8');
+  await writeFile(
+    join(root, 'config-utl/config.mjs'),
+    "export default async function extractConfig() { return { forbidden: [{ name: 'no-new-debt' }] }; }\n",
+    'utf8',
+  );
+  await writeFile(
+    join(root, 'config-utl/options.mjs'),
+    'export default async function extractOptions() { return { cache: true }; }\n',
+    'utf8',
+  );
+  await writeFile(join(root, '.dependency-cruiser.mjs'), 'export default {};\n', 'utf8');
+}
+
+test('dependency-cruiser still reports a new violation when a baseline is in place', async () => {
+  await withWorkspace(async root => {
+    await writeFakeDependencyCruiser(root, `export async function cruise(_files, options) {
+  if (options.ignoreKnown !== true) throw new Error('baseline was not forwarded');
+  return {
+    output: JSON.stringify({
+      summary: {
+        totalCruised: 3,
+        violations: [{
+          rule: { name: 'no-new-debt', severity: 'error' },
+          from: 'src/domain/order.ts',
+          to: 'src/infrastructure/db.ts',
+        }],
+      },
+    }),
+  };
+}
+`);
+    await writeFile(
+      join(root, '.dependency-cruiser-known-violations.json'),
+      JSON.stringify([{ rule: { name: 'no-new-debt', severity: 'error' } }]),
+      'utf8',
+    );
+
+    const adapter = dependencyCruiser({
+      configFile: '.dependency-cruiser.mjs',
+      knownViolationsFile: '.dependency-cruiser-known-violations.json',
+      rules: { noNewDebt: 'no-new-debt' },
+    });
+    const check = await adapter.check.run({ root, rules: [adapter.rules.noNewDebt.id] });
+
+    assert.equal(check.verdict, 'fail');
+    assert.equal(check.breaches.length, 1);
+    assert.equal(check.breaches[0]?.rule, 'dependency-cruiser/no-new-debt');
+  });
+});
+
+test('dependency-cruiser refuses when the baseline file is not a JSON array', async () => {
+  await withWorkspace(async root => {
+    await writeFakeDependencyCruiser(root, `export async function cruise() {
+  throw new Error('cruise must not run with an invalid baseline');
+}
+`);
+    await writeFile(join(root, '.dependency-cruiser-known-violations.json'), '{ "not": "an array" }', 'utf8');
+
+    const adapter = dependencyCruiser({
+      configFile: '.dependency-cruiser.mjs',
+      knownViolationsFile: '.dependency-cruiser-known-violations.json',
+      rules: { noNewDebt: 'no-new-debt' },
+    });
+    const check = await adapter.check.run({ root, rules: [adapter.rules.noNewDebt.id] });
+
+    assert.equal(check.verdict, 'refuse');
+    assert.equal(check.why.code, 'dependency-cruiser-known-violations-invalid');
+  });
+});

--- a/tests/adapters/dependency-cruiser.test.ts
+++ b/tests/adapters/dependency-cruiser.test.ts
@@ -1,11 +1,15 @@
 import assert from 'node:assert/strict';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import test from 'node:test';
+import { dependencyCruiser } from '@redproof/dependency-cruiser';
 import { defineRules, type Rule } from 'redproof';
 import {
   violationDiagnostic,
   violationsToBreaches,
   type DependencyCruiserViolation,
 } from '../../packages/dependency-cruiser/src/model.ts';
+import { withWorkspace } from '../helpers/workspace.ts';
 
 const rules = defineRules({
   domain: {
@@ -68,4 +72,61 @@ test('dependency-cruiser preserves cycle/via evidence as diagnostic detail', () 
     }).detail,
     'Cycle: src/a.ts -> src/b.ts -> src/a.ts',
   );
+});
+
+test('dependency-cruiser self-hosts with baseline violations and cache disabled', async () => {
+  await withWorkspace(async root => {
+    await mkdir(join(root, 'src'), { recursive: true });
+    await mkdir(join(root, 'config-utl'), { recursive: true });
+    await writeFile(join(root, 'package.json'), JSON.stringify({
+      name: 'dependency-cruiser',
+      type: 'module',
+      exports: {
+        '.': './main.mjs',
+        './config-utl/extract-depcruise-config': './config-utl/config.mjs',
+        './config-utl/extract-depcruise-options': './config-utl/options.mjs',
+      },
+    }), 'utf8');
+    await writeFile(join(root, 'main.mjs'), `export async function cruise(_files, options) {
+  if (options.cache !== false) throw new Error('cache must be disabled');
+  if (options.ignoreKnown !== true || options.knownViolations.length !== 1) {
+    throw new Error('known violations were not loaded');
+  }
+  return { output: JSON.stringify({ summary: { totalCruised: 1, violations: [] } }) };
+}
+`, 'utf8');
+    await writeFile(
+      join(root, 'config-utl/config.mjs'),
+      "export default async function extractConfig() { return { forbidden: [{ name: 'no-new-debt' }] }; }\n",
+      'utf8',
+    );
+    await writeFile(
+      join(root, 'config-utl/options.mjs'),
+      'export default async function extractOptions() { return { cache: true }; }\n',
+      'utf8',
+    );
+    await writeFile(
+      join(root, '.dependency-cruiser.mjs'),
+      'export default {};\n',
+      'utf8',
+    );
+    await writeFile(
+      join(root, '.dependency-cruiser-known-violations.json'),
+      JSON.stringify([{ rule: { name: 'no-new-debt', severity: 'error' } }]),
+      'utf8',
+    );
+
+    const adapter = dependencyCruiser({
+      configFile: '.dependency-cruiser.mjs',
+      knownViolationsFile: '.dependency-cruiser-known-violations.json',
+      rules: { noNewDebt: 'no-new-debt' },
+    });
+    const check = await adapter.check.run({
+      root,
+      rules: [adapter.rules.noNewDebt.id],
+    });
+
+    assert.equal(check.verdict, 'pass');
+    assert.equal(check.scan.inspected, 1);
+  });
 });


### PR DESCRIPTION
## Summary

- load dependency-cruiser lazily so its adapter can run inside dependency-cruiser itself
- accept a committed known-violations baseline and report only new selected violations
- force dependency-cruiser caching off so RED proof mutations cannot reuse stale results
- document the option and cover self-hosting, baseline forwarding, and cache override

## Battle-test evidence

This was found while running Redproof against dependency-cruiser itself. The real fixture passes 4 Gates, 8 Rules, and all 12 RED/GREEN proofs with this branch packed and installed.

## Verification

- `npm run check` — 135/135 tests plus typecheck, docs typecheck, fixture check/prove/describe
- `npm run verify:package` — all five packages pack, install, import, and type-check in a clean consumer