### PR TITLE
Discover config modules across package types

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,10 @@ export default defineConfig({
 });
 ```
 
+The CLI also discovers `redproof.config.mts`, `.mjs`, `.cts`, `.cjs`, and
+`.js`. CommonJS projects can use `redproof.config.mjs` to keep the config and
+Gate modules in ESM without adding `"type": "module"` to the whole package.
+
 A typical project:
 
 ```text

--- a/fixtures/commonjs-config/gates/pass.mjs
+++ b/fixtures/commonjs-config/gates/pass.mjs
@@ -1,0 +1,27 @@
+import { counting, defineAdapter, defineGate, pass } from 'redproof';
+
+const rule = {
+  id: 'commonjs-config/loads-esm',
+  description: 'loads an ESM config in a CommonJS project',
+};
+
+export default defineGate({
+  id: 'commonjs-config',
+  adapter: defineAdapter({
+    kind: 'fixture',
+    rules: { rule },
+    check: {
+      description: 'pass after config discovery',
+      counting: counting.supported,
+      async run() {
+        const startedAt = new Date().toISOString();
+        return pass({
+          source: 'commonjs-config',
+          startedAt,
+          finishedAt: new Date().toISOString(),
+          inspected: 1,
+        });
+      },
+    },
+  }),
+});

--- a/fixtures/commonjs-config/package.json
+++ b/fixtures/commonjs-config/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "commonjs-config",
+  "private": true,
+  "type": "commonjs",
+  "dependencies": {
+    "redproof": "file:../../packages/redproof"
+  }
+}

--- a/fixtures/commonjs-config/redproof.config.mjs
+++ b/fixtures/commonjs-config/redproof.config.mjs
@@ -1,0 +1,6 @@
+import { defineConfig } from 'redproof';
+
+export default defineConfig({
+  root: '.',
+  gatesRoot: 'gates/**/*.mjs',
+});

--- a/fixtures/config-precedence/gates-mjs/from-mjs.mjs
+++ b/fixtures/config-precedence/gates-mjs/from-mjs.mjs
@@ -1,0 +1,27 @@
+import { counting, defineAdapter, defineGate, pass } from 'redproof';
+
+const rule = {
+  id: 'from-mjs/loaded',
+  description: 'the .mjs config was discovered first',
+};
+
+export default defineGate({
+  id: 'from-mjs',
+  adapter: defineAdapter({
+    kind: 'fixture',
+    rules: { rule },
+    check: {
+      description: 'pass after config discovery',
+      counting: counting.supported,
+      async run() {
+        const startedAt = new Date().toISOString();
+        return pass({
+          source: 'from-mjs',
+          startedAt,
+          finishedAt: new Date().toISOString(),
+          inspected: 1,
+        });
+      },
+    },
+  }),
+});

--- a/fixtures/config-precedence/gates-ts/from-ts.ts
+++ b/fixtures/config-precedence/gates-ts/from-ts.ts
@@ -1,0 +1,27 @@
+import { counting, defineAdapter, defineGate, pass } from 'redproof';
+
+const rule = {
+  id: 'from-ts/loaded',
+  description: 'the .ts config was discovered first',
+};
+
+export default defineGate({
+  id: 'from-ts',
+  adapter: defineAdapter({
+    kind: 'fixture',
+    rules: { rule },
+    check: {
+      description: 'pass after config discovery',
+      counting: counting.supported,
+      async run() {
+        const startedAt = new Date().toISOString();
+        return pass({
+          source: 'from-ts',
+          startedAt,
+          finishedAt: new Date().toISOString(),
+          inspected: 1,
+        });
+      },
+    },
+  }),
+});

--- a/fixtures/config-precedence/package.json
+++ b/fixtures/config-precedence/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "config-precedence",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "redproof": "file:../../packages/redproof"
+  }
+}

--- a/fixtures/config-precedence/redproof.config.mjs
+++ b/fixtures/config-precedence/redproof.config.mjs
@@ -1,0 +1,6 @@
+import { defineConfig } from 'redproof';
+
+export default defineConfig({
+  root: '.',
+  gatesRoot: 'gates-mjs/**/*.mjs',
+});

--- a/fixtures/config-precedence/redproof.config.ts
+++ b/fixtures/config-precedence/redproof.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'redproof';
+
+export default defineConfig({
+  root: '.',
+  gatesRoot: 'gates-ts/**/*.ts',
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,11 @@
         "redproof": "file:../../packages/redproof"
       }
     },
+    "fixtures/config-precedence": {
+      "dependencies": {
+        "redproof": "file:../../packages/redproof"
+      }
+    },
     "fixtures/dependency-cruiser-project": {
       "name": "redproof-dependency-cruiser-fixture",
       "dependencies": {
@@ -2175,6 +2180,10 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
+    },
+    "node_modules/config-precedence": {
+      "resolved": "fixtures/config-precedence",
+      "link": true
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,11 @@
         "node": ">=24"
       }
     },
+    "fixtures/commonjs-config": {
+      "dependencies": {
+        "redproof": "file:../../packages/redproof"
+      }
+    },
     "fixtures/composition-custom-mutation": {
       "name": "redproof-composition-custom-mutation-fixture",
       "dependencies": {
@@ -2160,6 +2165,10 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/commonjs-config": {
+      "resolved": "fixtures/commonjs-config",
+      "link": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",

--- a/packages/redproof/src/cli.ts
+++ b/packages/redproof/src/cli.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { dirname, isAbsolute, resolve } from 'node:path';
 import { describeProject } from './runtime/describe.ts';
 import { GateSelectionError } from './runtime/discovery.ts';
@@ -34,7 +34,7 @@ never change what a Gate inspects; a Gate owns its own scope.
   redproof check gates/*.ts
 
 Options:
-  --config <path>       Path to redproof.config.ts
+  --config <path>       Path to a Redproof config file
   --reporter <reporter> Select an output reporter
   --outputFile <path>   Write reporter output to a file
   --no-color            Disable colored output
@@ -42,14 +42,31 @@ Options:
   -h, --help            Show this help
   -v, --version         Show the installed version`;
 
-function configArg(argv: readonly string[]): string | undefined {
+const DEFAULT_CONFIG_FILES = [
+  'redproof.config.ts',
+  'redproof.config.mts',
+  'redproof.config.mjs',
+  'redproof.config.cts',
+  'redproof.config.cjs',
+  'redproof.config.js',
+] as const;
+
+function configArg(argv: readonly string[]): string | null | undefined {
   const inline = argv.find(arg => arg.startsWith('--config='));
   if (inline !== undefined) return inline.slice('--config='.length) || undefined;
 
   const index = argv.indexOf('--config');
-  if (index < 0) return 'redproof.config.ts';
+  if (index < 0) return null;
   const value = argv[index + 1];
   return value && !value.startsWith('-') ? value : undefined;
+}
+
+async function defaultConfigPath(): Promise<string> {
+  for (const file of DEFAULT_CONFIG_FILES) {
+    const path = resolve(file);
+    if (await stat(path).then(entry => entry.isFile(), () => false)) return path;
+  }
+  return resolve(DEFAULT_CONFIG_FILES[0]);
 }
 
 async function packageVersion(): Promise<string> {
@@ -104,7 +121,7 @@ async function main(): Promise<number> {
     console.error('Option --config requires a path.');
     return 2;
   }
-  const configPath = resolve(configValue);
+  const configPath = configValue === null ? await defaultConfigPath() : resolve(configValue);
 
   const gateFiles = positionalArgs(args);
 

--- a/packages/redproof/src/cli.ts
+++ b/packages/redproof/src/cli.ts
@@ -34,7 +34,9 @@ never change what a Gate inspects; a Gate owns its own scope.
   redproof check gates/*.ts
 
 Options:
-  --config <path>       Path to a Redproof config file
+  --config <path>       Path to a Redproof config file. Without it, the CLI
+                        looks for redproof.config.ts, .mts, .mjs, .cts, .cjs,
+                        then .js, in that order.
   --reporter <reporter> Select an output reporter
   --outputFile <path>   Write reporter output to a file
   --no-color            Disable colored output
@@ -61,12 +63,12 @@ function configArg(argv: readonly string[]): string | null | undefined {
   return value && !value.startsWith('-') ? value : undefined;
 }
 
-async function defaultConfigPath(): Promise<string> {
+async function defaultConfigPath(): Promise<string | null> {
   for (const file of DEFAULT_CONFIG_FILES) {
     const path = resolve(file);
     if (await stat(path).then(entry => entry.isFile(), () => false)) return path;
   }
-  return resolve(DEFAULT_CONFIG_FILES[0]);
+  return null;
 }
 
 async function packageVersion(): Promise<string> {
@@ -121,7 +123,16 @@ async function main(): Promise<number> {
     console.error('Option --config requires a path.');
     return 2;
   }
-  const configPath = configValue === null ? await defaultConfigPath() : resolve(configValue);
+  const discovered = configValue === null ? await defaultConfigPath() : resolve(configValue);
+  if (discovered === null) {
+    console.error(
+      `No Redproof config found in ${process.cwd()}.\n`
+      + `Looked for ${DEFAULT_CONFIG_FILES.join(', ')}.\n`
+      + 'Create one, or pass --config <path>.',
+    );
+    return 2;
+  }
+  const configPath = discovered;
 
   const gateFiles = positionalArgs(args);
 

--- a/tests/reporter/cli.test.ts
+++ b/tests/reporter/cli.test.ts
@@ -4,6 +4,7 @@ import { resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import test from 'node:test';
 import { parseReporterArgs } from 'redproof';
+import { withWorkspace } from '../helpers/workspace.ts';
 
 test('reporter CLI parser supports one stdout reporter plus file reporters', () => {
   assert.deepEqual(parseReporterArgs([
@@ -80,6 +81,45 @@ test('CLI discovers an ESM config in a CommonJS project', () => {
   const report = JSON.parse(result.stdout);
   assert.equal(report.status, 'passed');
   assert.deepEqual(report.gates.map((gate: { id: string }) => gate.id), ['commonjs-config']);
+});
+
+test('CLI prefers redproof.config.ts when several config files exist', () => {
+  const result = spawnSync(process.execPath, [
+    '--disable-warning=ExperimentalWarning',
+    '--experimental-strip-types',
+    resolve('packages/redproof/src/cli.ts'),
+    'check',
+    '--reporter=json',
+  ], { cwd: resolve('fixtures/config-precedence'), encoding: 'utf8' });
+
+  assert.equal(result.status, 0, result.stderr);
+  const report = JSON.parse(result.stdout);
+  assert.deepEqual(report.gates.map((gate: { id: string }) => gate.id), ['from-ts']);
+});
+
+test('CLI names every config file it looked for when none exists', async () => {
+  await withWorkspace(async root => {
+    const result = spawnSync(process.execPath, [
+      '--disable-warning=ExperimentalWarning',
+      '--experimental-strip-types',
+      resolve('packages/redproof/src/cli.ts'),
+      'check',
+    ], { cwd: root, encoding: 'utf8' });
+
+    assert.equal(result.status, 2, result.stdout);
+    assert.match(result.stderr, /No Redproof config found/);
+    for (const file of [
+      'redproof.config.ts',
+      'redproof.config.mts',
+      'redproof.config.mjs',
+      'redproof.config.cts',
+      'redproof.config.cjs',
+      'redproof.config.js',
+    ]) {
+      assert.ok(result.stderr.includes(file), `stderr must name ${file}`);
+    }
+    assert.doesNotMatch(result.stderr, /ERR_MODULE_NOT_FOUND|at main|node:internal/);
+  });
 });
 
 test('CLI writes JSON output relative to the project root', async () => {

--- a/tests/reporter/cli.test.ts
+++ b/tests/reporter/cli.test.ts
@@ -67,6 +67,21 @@ test('CLI reports a missing config value without an internal stack trace', () =>
   assert.doesNotMatch(result.stderr, /node:path|at main|ERR_/);
 });
 
+test('CLI discovers an ESM config in a CommonJS project', () => {
+  const result = spawnSync(process.execPath, [
+    '--disable-warning=ExperimentalWarning',
+    '--experimental-strip-types',
+    resolve('packages/redproof/src/cli.ts'),
+    'check',
+    '--reporter=json',
+  ], { cwd: resolve('fixtures/commonjs-config'), encoding: 'utf8' });
+
+  assert.equal(result.status, 0, result.stderr);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.status, 'passed');
+  assert.deepEqual(report.gates.map((gate: { id: string }) => gate.id), ['commonjs-config']);
+});
+
 test('CLI writes JSON output relative to the project root', async () => {
   const output = resolve('fixtures/pass-single/.redproof/reporter-test.json');
   await rm(output, { force: true });


### PR DESCRIPTION
## Summary

- discover supported Redproof config extensions when `--config` is omitted
- keep `redproof.config.ts` first for compatibility while supporting `.mts`, `.mjs`, `.cts`, `.cjs`, and `.js`
- document the CommonJS-project pattern and add a real CLI regression fixture

## Battle-test reproduction

Dependency-cruiser is a CommonJS package. Redproof previously defaulted only to `redproof.config.ts`, which Node classified as CommonJS and rejected when it contained the documented ESM imports. With this branch, an ESM `redproof.config.mjs` is discovered automatically and the real dependency-cruiser fixture passes 4 Gates and 8 Rules without `--config`.

## Verification

- `npm run check` — 135/135 tests plus typecheck, docs typecheck, fixture check/prove/describe
- `npm run verify:package` — all clean packed-consumer checks pass
- real dependency-cruiser fixture — default `redproof check` passes 4/4 Gates and 8/8 Rules