### PR TITLE
Support dependencies in nested proof copies

### DIFF
--- a/packages/redproof/src/runtime/workspace.ts
+++ b/packages/redproof/src/runtime/workspace.ts
@@ -8,6 +8,7 @@ import {
   readFile,
   readdir,
   readlink,
+  realpath,
   rm,
   stat,
   symlink,
@@ -141,8 +142,9 @@ async function findDependencies(projectRoot: string): Promise<string | null> {
     try {
       // Follow a dependency-directory symlink. A Redproof run can itself execute
       // Redproof in a copied workspace, so the nearest node_modules may already
-      // be the link created by an outer copy.
-      if ((await stat(candidate)).isDirectory()) return candidate;
+      // be the link created by an outer copy. Resolve to the real directory, so
+      // a nested copy never links through the copy above it.
+      if ((await stat(candidate)).isDirectory()) return realpath(candidate);
     } catch {
       // keep walking up
     }

--- a/packages/redproof/src/runtime/workspace.ts
+++ b/packages/redproof/src/runtime/workspace.ts
@@ -9,6 +9,7 @@ import {
   readdir,
   readlink,
   rm,
+  stat,
   symlink,
 } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -138,7 +139,10 @@ async function findDependencies(projectRoot: string): Promise<string | null> {
     const candidate = join(current, 'node_modules');
 
     try {
-      if ((await lstat(candidate)).isDirectory()) return candidate;
+      // Follow a dependency-directory symlink. A Redproof run can itself execute
+      // Redproof in a copied workspace, so the nearest node_modules may already
+      // be the link created by an outer copy.
+      if ((await stat(candidate)).isDirectory()) return candidate;
     } catch {
       // keep walking up
     }

--- a/tests/workspace.test.ts
+++ b/tests/workspace.test.ts
@@ -45,3 +45,32 @@ test('copies tracked nested node_modules fixtures while linking root dependencie
     }
   });
 });
+
+test('nested proof copies inherit dependencies from an outer copied workspace', async () => {
+  await withWorkspace(async root => {
+    await mkdir(join(root, 'node_modules/root-package'), { recursive: true });
+    await writeFile(
+      join(root, 'node_modules/root-package/package.json'),
+      '{"name":"root-package","version":"1.0.0"}\n',
+      'utf8',
+    );
+    await mkdir(join(root, 'fixtures/project'), { recursive: true });
+    await writeFile(join(root, 'fixtures/project/package.json'), '{"private":true}\n', 'utf8');
+
+    const outer = await copyGateWorkspace(root, 'outer');
+    try {
+      const inner = await copyGateWorkspace(join(outer.root, 'fixtures/project'), 'inner');
+      try {
+        assert.equal((await lstat(join(inner.root, 'node_modules'))).isSymbolicLink(), true);
+        assert.equal(
+          await readFile(join(inner.root, 'node_modules/root-package/package.json'), 'utf8'),
+          '{"name":"root-package","version":"1.0.0"}\n',
+        );
+      } finally {
+        await releaseGateWorkspace(inner);
+      }
+    } finally {
+      await releaseGateWorkspace(outer);
+    }
+  });
+});

--- a/tests/workspace.test.ts
+++ b/tests/workspace.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { lstat, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { lstat, mkdir, readFile, readlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import test from 'node:test';
 
@@ -71,6 +71,40 @@ test('nested proof copies inherit dependencies from an outer copied workspace', 
       }
     } finally {
       await releaseGateWorkspace(outer);
+    }
+  });
+});
+
+test('a nested copy links to the real dependencies, not to the copy above it', async () => {
+  await withWorkspace(async root => {
+    await mkdir(join(root, 'node_modules/root-package'), { recursive: true });
+    await writeFile(
+      join(root, 'node_modules/root-package/package.json'),
+      '{"name":"root-package","version":"1.0.0"}\n',
+      'utf8',
+    );
+    await mkdir(join(root, 'fixtures/project'), { recursive: true });
+    await writeFile(join(root, 'fixtures/project/package.json'), '{"private":true}\n', 'utf8');
+
+    const outer = await copyGateWorkspace(root, 'outer');
+    const inner = await copyGateWorkspace(join(outer.root, 'fixtures/project'), 'inner');
+    try {
+      // The inner link must not point at the outer copy, or releasing the outer
+      // copy first would take the inner copy's dependencies with it.
+      const target = await readlink(join(inner.root, 'node_modules'));
+      assert.ok(
+        !target.startsWith(outer.root),
+        `inner node_modules must not link through the outer copy, got ${target}`,
+      );
+
+      await releaseGateWorkspace(outer);
+
+      assert.equal(
+        await readFile(join(inner.root, 'node_modules/root-package/package.json'), 'utf8'),
+        '{"name":"root-package","version":"1.0.0"}\n',
+      );
+    } finally {
+      await releaseGateWorkspace(inner);
     }
   });
 });


### PR DESCRIPTION
## Problem

Redproof copies a workspace to run a proof in isolation. It does not copy
`node_modules`. It creates a symbolic link instead.

`findDependencies` used `lstat`, which does not follow a symbolic link. So a
`node_modules` that was already a link did not look like a directory, and the
search walked past it.

That breaks nesting. When Redproof runs inside one of its own copies, the inner
copy meets the outer copy's link, skips it, and finds nothing:

```text
Error: ENOENT: no such file or directory, lstat
  '/var/.../redproof-inner-Xq2YQ8/node_modules'
```

The inner Gate then cannot import `redproof` or any adapter package.

## Fix

`findDependencies` now uses `stat`, which follows a link, and returns
`realpath(candidate)`.

Following the link alone is not enough. It returns the link itself, so each copy
would link to the copy above it:

```text
three/node_modules -> two/node_modules -> one/node_modules -> root/node_modules
```

That chain works only while every link survives. Releasing a middle copy takes
an inner copy's dependencies with it. `realpath` resolves the real directory, so
every copy links straight to it and no chain exists.

## Verification

`npm run check` exits 0. 142 tests, 142 pass, 0 fail. All documentation examples
type-check. `npm run verify:package` exits 0 with 50 PASS.

Two tests guard this, and each was proven able to fail.

The first plants the original bug. With `lstat` restored, it fails because the
inner copy has no `node_modules` at all.

The second plants the chain. With `return candidate` restored, it fails and
names the offending path:

```text
AssertionError: inner node_modules must not link through the outer copy,
got /var/.../redproof-outer-MXgb4B/node_modules
```

During that second break the first test stayed green, so the two tests guard
different faults.

Both were restored, and the suite is green again.
