### PR TITLE
Let a command runner state what it will run

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,9 @@ const gate = defineGate({
 
 Completed failure exits breach the selected Rule. Missing executables, timeouts, signals, output overflow, and explicitly unclassified exits produce **REFUSE**. Use `commands()` from the same subpath for deterministic sequential or bounded-parallel command groups.
 
+See **[Command Checks](https://github.com/schalermthai/redproof/blob/main/docs/commands.md)** for exit-code policy,
+command groups, and what a Check reports about itself.
+
 See **[Composing Redproof](https://github.com/schalermthai/redproof/blob/main/docs/composition.md)** to create your own Gates, Rules, Checks, Proofs, Mutations, and Adapters.
 
 For execution isolation, machine-readable reports, VS Code, and other workflows, see **[Tutorials](https://github.com/schalermthai/redproof/blob/main/docs/tutorials/README.md)**.
@@ -350,6 +353,7 @@ npm run redproof:describe -- gates/no-todo.ts
 ## Learn more
 
 - **[Built-in integrations](https://github.com/schalermthai/redproof/blob/main/docs/adapters.md)**
+- **[Command Checks](https://github.com/schalermthai/redproof/blob/main/docs/commands.md)**
 - **[Composing Redproof](https://github.com/schalermthai/redproof/blob/main/docs/composition.md)**
 - **[Tutorials](https://github.com/schalermthai/redproof/blob/main/docs/tutorials/README.md)**
 - **[Legacy modernization](https://github.com/schalermthai/redproof/blob/main/docs/legacy-modernization.md)**

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -117,6 +117,9 @@ The default description uses the command's base name. A description therefore
 reads the same on every machine, even when `command` is an absolute path. Set
 `description` yourself when a sentence explains more than the command line does.
 
+A Check built from `redproof/command` reports itself the same way. See
+**[Command Checks](commands.md#what-a-check-says-about-itself)**.
+
 ## ESLint
 
 Package:
@@ -258,5 +261,8 @@ A useful rule of thumb:
 > Create a new Adapter when the external system introduces a new policy model.
 
 > Create a runner or parser when it only introduces a new invocation method or data format.
+
+When the tool is simply an executable, a Check is enough. See **[Command
+Checks](commands.md)**.
 
 For writing your own integration, continue with **[Composing Redproof](composition.md#creating-an-adapter)**.

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -94,6 +94,29 @@ defineTestReport(...)
 
 Create a new full Adapter only when a tool introduces a genuinely different policy model.
 
+### What a command runner reports about itself
+
+A command runner states what it will run. `redproof describe` uses this, so a
+Gate does not need a hand-written sentence that can drift from the real command.
+
+```ts
+import { runner } from '@redproof/testing';
+
+const built = runner.command({ command: 'npm', args: ['test'] });
+
+built.description;                                  // 'run npm test'
+built.plan;                                         // { command: 'npm', args: ['test'] }
+built.argsFor?.({ root: '.', reportFile: 'r.xml' }); // ['test']
+```
+
+`plan.args` is present only when the arguments are a fixed list. When `args` is
+a function, the arguments depend on the run, so `plan` carries the command
+alone and `argsFor` answers for one run.
+
+The default description uses the command's base name. A description therefore
+reads the same on every machine, even when `command` is an absolute path. Set
+`description` yourself when a sentence explains more than the command line does.
+
 ## ESLint
 
 Package:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,140 @@
+# Command Checks
+
+A **Check** decides whether the Rules of a Gate hold. When a guardrail already
+exists as an executable, you do not need to write that Check by hand.
+
+`redproof/command` builds a Check from a command line. It is part of the Check
+layer, not an Adapter. Reach for an Adapter only when a tool brings its own
+policy model, such as a rule catalogue or a score.
+
+- [One command](#one-command)
+- [Exit codes decide the verdict](#exit-codes-decide-the-verdict)
+- [When a command REFUSES](#when-a-command-refuses)
+- [Several commands](#several-commands)
+- [Order and precedence](#order-and-precedence)
+- [What a Check says about itself](#what-a-check-says-about-itself)
+
+## One command
+
+Use `command()` when one executable answers for one Rule, and its process status
+is the trustworthy result.
+
+```ts fragment
+import { command } from 'redproof/command';
+
+const check = command({
+  rule: rules.docs,
+  command: 'npm',
+  args: ['run', 'lint:docs'],
+  timeoutMs: 60_000,
+});
+```
+
+Relative `cwd` values resolve inside the Gate workspace and cannot escape it.
+Child output is captured for diagnostics. It is never inherited by reporter
+output, so a machine-readable report stays clean.
+
+## Exit codes decide the verdict
+
+By default, exit code `0` produces PASS. Any other ordinary exit code breaches
+`rule`.
+
+Give an explicit policy when the tool separates findings from configuration or
+invocation errors.
+
+```ts fragment
+const check = command({
+  rule: rules.lint,
+  command: 'eslint',
+  args: ['src'],
+  exitCodes: {
+    pass: [0],
+    breach: [1],
+  },
+});
+```
+
+Here exit code `2` produces REFUSE. It is neither a passing exit nor a breach
+exit, so the Check cannot decide.
+
+## When a command REFUSES
+
+REFUSE means the Check could not make a trustworthy decision. It is never a
+pass, and it is never a rule breach. These five cases produce it.
+
+- The executable cannot start.
+- The process exceeds `timeoutMs`.
+- The process is terminated by a signal.
+- Combined stdout and stderr exceed `maxOutputBytes`, which defaults to 10 MiB.
+- The process returns an exit code that no explicit policy covers.
+
+## Several commands
+
+Use `commands()` when one Gate depends on more than one executable. Sequential
+execution is the safe default.
+
+```ts fragment
+import { commands } from 'redproof/command';
+
+const check = commands({
+  entries: [
+    { rule: rules.metadata, command: 'npm', args: ['run', 'lint:package-json'] },
+    { rule: rules.ordering, command: 'npm', args: ['run', 'lint:package-json-sorting'] },
+  ],
+});
+```
+
+Parallel execution is explicit and bounded.
+
+```ts fragment
+const check = commands({
+  mode: 'parallel',
+  maxAtOnce: 2,
+  entries: [
+    { rule: rules.docs, command: 'npm', args: ['run', 'lint:docs'] },
+    { rule: rules.types, command: 'npm', args: ['run', 'lint:types'] },
+  ],
+});
+```
+
+## Order and precedence
+
+Results stay in declaration order, even when commands finish in a different
+order. A report therefore reads the same on every run.
+
+Sequential execution stops at the first REFUSE.
+
+Parallel execution waits for the started group. REFUSE then takes precedence
+over any collected Breaches, because the Gate could not make a complete
+decision.
+
+## What a Check says about itself
+
+A command Check describes itself from its own command line. `redproof describe`
+prints that description, so a reader can see what a Gate will run.
+
+```text
+Check:
+  run npm run lint:docs
+```
+
+A group names its commands.
+
+```text
+Check:
+  run 3 commands: workspace TypeScript, documentation examples, documentation fragment budget
+```
+
+A group entry uses its `label` when it has one, and the base name of its command
+otherwise. The base name is used on purpose. A description reads the same on
+every machine, even when `command` holds an absolute path.
+
+Set `description` yourself when a sentence explains more than the command line
+does. An explicit description always wins.
+
+## Next
+
+- **[Composing Redproof](composition.md)** for Rules, Checks, Proofs, and
+  Mutations.
+- **[Built-in integrations](adapters.md)** for tools that bring their own policy
+  model.

--- a/docs/composition.md
+++ b/docs/composition.md
@@ -397,70 +397,12 @@ This keeps the set of Rules the Check may breach type-safe.
 
 ### Command Checks
 
-Use `redproof/command` when an existing guardrail is exposed as an executable and its process status is the trustworthy policy result:
+When the guardrail is already an executable, `command()` and `commands()` from
+`redproof/command` build the Check for you. They handle exit-code policy,
+timeouts, output limits, and REFUSE.
 
-```ts fragment
-import { command } from 'redproof/command';
-
-const check = command({
-  rule: rules.docs,
-  command: 'npm',
-  args: ['run', 'lint:docs'],
-  timeoutMs: 60_000,
-});
-```
-
-By default, exit code `0` produces PASS and any other ordinary exit code breaches `rule`. Process infrastructure failures produce REFUSE:
-
-- the executable cannot start
-- the process exceeds `timeoutMs`
-- the process is terminated by a signal
-- combined stdout and stderr exceed `maxOutputBytes` (10 MiB by default)
-- the process returns an exit code not covered by an explicit policy
-
-Use an explicit policy when the tool distinguishes findings from configuration or invocation errors:
-
-```ts fragment
-const check = command({
-  rule: rules.lint,
-  command: 'eslint',
-  args: ['src'],
-  exitCodes: {
-    pass: [0],
-    breach: [1],
-  },
-});
-```
-
-Here, exit code `2` produces REFUSE because it is neither a passing nor a breach exit. Child stdout and stderr are captured for diagnostics and never inherited by reporter stdout. Relative `cwd` values resolve inside the Gate workspace and cannot escape it.
-
-Use `commands()` when one Gate depends on several executables. Sequential execution is the safe default:
-
-```ts fragment
-import { commands } from 'redproof/command';
-
-const check = commands({
-  entries: [
-    { rule: rules.metadata, command: 'npm', args: ['run', 'lint:package-json'] },
-    { rule: rules.ordering, command: 'npm', args: ['run', 'lint:package-json-sorting'] },
-  ],
-});
-```
-
-Parallel execution is explicit and bounded:
-
-```ts fragment
-const check = commands({
-  mode: 'parallel',
-  maxAtOnce: 2,
-  entries: [
-    { rule: rules.docs, command: 'npm', args: ['run', 'lint:docs'] },
-    { rule: rules.types, command: 'npm', args: ['run', 'lint:types'] },
-  ],
-});
-```
-
-Results remain in declaration order even when commands finish in a different order. Sequential execution stops at the first REFUSE. Parallel execution waits for the started group, and REFUSE takes precedence over collected Breaches because the Gate could not make a complete decision.
+See **[Command Checks](commands.md)** for the full API, command groups,
+sequential and parallel execution, and what a Check reports about itself.
 
 ## Creating an Adapter
 

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -24,4 +24,6 @@ Use the compact reporter with a problem matcher or open SARIF output with a SARI
 
 ## Composition
 
+For a guardrail that is already an executable, see **[Command Checks](../commands.md)**.
+
 For authoring Rules, Checks, Proofs, Mutations, and Adapters, see **[Composing Redproof](../composition.md)**.

--- a/gates/checks/node-test-suite.ts
+++ b/gates/checks/node-test-suite.ts
@@ -1,22 +1,23 @@
 import { globSync } from 'node:fs';
-import { runner, type TestRunner, type TestRunnerContext } from '@redproof/testing';
+import { runner, type TestRunner } from '@redproof/testing';
 import { node, stripTypes } from '../support/node.ts';
 
-/** The Node arguments that run `files` under the test runner, reporting JUnit XML. */
-export function nodeTestArgs(files: string, ctx: TestRunnerContext): string[] {
-  return stripTypes(
-    '--test',
-    '--test-reporter=junit',
-    `--test-reporter-destination=${ctx.reportFile}`,
-    ...globSync(files, { cwd: ctx.root }).sort(),
-  );
-}
-
-/** Run every matching test file under `node --test`, reporting JUnit XML. */
+/**
+ * Run every matching test file under `node --test`, reporting JUnit XML.
+ *
+ * The file list depends on the workspace, so the arguments are built per run.
+ * `runner.command` exposes that builder as `argsFor`, and the description names
+ * the pattern, so neither can drift from what actually runs.
+ */
 export function nodeTestSuite(options: { readonly files: string }): TestRunner {
   return runner.command({
     command: node,
-    description: 'run the complete Node test suite with a structured JUnit report',
-    args: ctx => nodeTestArgs(options.files, ctx),
+    description: `run ${options.files} under node --test with a JUnit report`,
+    args: ctx => stripTypes(
+      '--test',
+      '--test-reporter=junit',
+      `--test-reporter-destination=${ctx.reportFile}`,
+      ...globSync(options.files, { cwd: ctx.root }).sort(),
+    ),
   });
 }

--- a/packages/redproof/src/command.ts
+++ b/packages/redproof/src/command.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process';
-import { isAbsolute, relative, resolve, sep } from 'node:path';
+import { basename, isAbsolute, relative, resolve, sep } from 'node:path';
 import { breach, counting, result } from './composition/check.ts';
 import type { Check, CheckResult, Scan } from './domain/check.ts';
 import type { Rule, RuleRef } from './domain/rule.ts';
@@ -261,9 +261,10 @@ export function command<const R extends RuleRef>(options: CommandCheckOptions<R>
   const exitCodes = normalizeExitCodes(options.exitCodes);
   const label = options.label ?? options.command;
   const maxOutputBytes = options.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES;
+  const invocation = [basename(options.command), ...(options.args ?? [])].join(' ');
 
   return {
-    description: options.description ?? `run ${label}`,
+    description: options.description ?? `run ${invocation}`,
     counting: counting.supported,
 
     async run(ctx): Promise<CheckResult<R>> {
@@ -385,7 +386,9 @@ export function commands<const R extends RuleRef>(options: CommandGroupOptions<R
   const source = groupSource(options);
 
   return {
-    description: options.description ?? `run ${checks.length} commands`,
+    description: options.description
+      ?? `run ${checks.length} commands: `
+        + options.entries.map(entry => entry.label ?? basename(entry.command)).join(', '),
     counting: counting.supported,
 
     async run(ctx): Promise<CheckResult<R>> {

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -259,6 +259,7 @@ export type {
   CommandArgs,
   CommandRunnerOptions,
 } from './runner.ts';
+export type { CommandPlan } from './model.ts';
 export type {
   TestCase,
   TestFailure,

--- a/packages/testing/src/model.ts
+++ b/packages/testing/src/model.ts
@@ -80,8 +80,18 @@ export type TestRunnerUnavailable = {
 
 export type TestRunnerResult = TestRunnerCompleted | TestRunnerUnavailable;
 
+export type CommandPlan = {
+  readonly command: string;
+  /** Absent when the arguments are computed from the run context. */
+  readonly args?: readonly string[];
+};
+
 export type TestRunner = {
   readonly description: string;
+  /** What this runner will execute, known without a run. */
+  readonly plan?: CommandPlan;
+  /** The exact arguments for one run. Present on command runners. */
+  argsFor?(ctx: TestRunnerContext): readonly string[];
   run(ctx: TestRunnerContext): Promise<TestRunnerResult>;
 };
 

--- a/packages/testing/src/runner.ts
+++ b/packages/testing/src/runner.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process';
-import type { TestRunner, TestRunnerContext, TestRunnerResult } from './model.ts';
+import { basename } from 'node:path';
+import type { CommandPlan, TestRunner, TestRunnerContext, TestRunnerResult } from './model.ts';
 
 export type CommandArgs = readonly string[] | ((ctx: TestRunnerContext) => readonly string[]);
 
@@ -15,9 +16,25 @@ function argsFor(args: CommandArgs | undefined, ctx: TestRunnerContext): readonl
   return typeof args === 'function' ? args(ctx) : args;
 }
 
+function planFor(options: CommandRunnerOptions): CommandPlan {
+  return typeof options.args === 'function' || options.args === undefined
+    ? { command: options.command }
+    : { command: options.command, args: options.args };
+}
+
+/** The command line, with no machine-specific directory in front of it. */
+function describePlan(plan: CommandPlan): string {
+  const name = basename(plan.command);
+  return plan.args?.length ? `run ${name} ${plan.args.join(' ')}` : `run ${name}`;
+}
+
 export function command(options: CommandRunnerOptions): TestRunner {
+  const plan = planFor(options);
+
   return {
-    description: options.description ?? `run ${options.command}`,
+    description: options.description ?? describePlan(plan),
+    plan,
+    argsFor: ctx => argsFor(options.args, ctx),
 
     async run(ctx): Promise<TestRunnerResult> {
       const args = argsFor(options.args, ctx);

--- a/tests/adapters/testing.test.ts
+++ b/tests/adapters/testing.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { writeFile } from 'node:fs/promises';
 import test from 'node:test';
-import { testing, report, parseJestJson, parseJunitXml, testRunBreaches, type TestRunner } from '@redproof/testing';
+import { testing, report, runner, parseJestJson, parseJunitXml, testRunBreaches, type TestRunner } from '@redproof/testing';
 import { defineRule } from 'redproof';
 import { withWorkspace } from '../helpers/workspace.ts';
 
@@ -220,4 +220,37 @@ test('the testing adapter rejects a rule name it does not know', () => {
     }),
     /Unknown testing rule option: "noPurpleTests"\. Known options: testsPass, noSkippedTests, noTodoTests\./,
   );
+});
+
+test('a command runner states the command line it will run', () => {
+  const built = runner.command({ command: '/usr/local/bin/npm', args: ['run', 'test'] });
+
+  assert.deepEqual(built.plan, { command: '/usr/local/bin/npm', args: ['run', 'test'] });
+  assert.equal(built.description, 'run npm run test');
+  assert.doesNotMatch(built.description, /\//, 'a description must not carry a machine path');
+});
+
+test('a computed argument list is reported per run, not in the plan', () => {
+  const built = runner.command({
+    command: 'node',
+    args: ctx => ['--test', `--out=${ctx.reportFile}`],
+  });
+
+  assert.deepEqual(built.plan, { command: 'node' });
+  assert.equal(built.description, 'run node');
+  assert.deepEqual(
+    built.argsFor?.({ root: '/tmp', reportFile: '/tmp/report.xml' }),
+    ['--test', '--out=/tmp/report.xml'],
+  );
+});
+
+test('an explicit runner description still wins over the command line', () => {
+  const built = runner.command({
+    command: 'npm',
+    args: ['test'],
+    description: 'run the acceptance suite',
+  });
+
+  assert.equal(built.description, 'run the acceptance suite');
+  assert.deepEqual(built.plan, { command: 'npm', args: ['test'] });
 });

--- a/tests/command.test.ts
+++ b/tests/command.test.ts
@@ -286,3 +286,27 @@ test('commands validates its execution policy at composition time', () => {
     /maxAtOnce must be a positive integer/,
   );
 });
+
+test('a command Check describes the real invocation, not an absolute path', () => {
+  const rule = defineRule({ id: 'probe/lint', description: 'Lint must pass.' });
+  const check = command({ rule, command: '/usr/local/bin/npm', args: ['run', 'lint'] });
+
+  assert.equal(check.description, 'run npm run lint');
+  assert.doesNotMatch(check.description, /\//, 'a description must not carry a machine path');
+});
+
+test('a command group names the commands it will run', () => {
+  const lint = defineRule({ id: 'probe/lint', description: 'Lint must pass.' });
+  const types = defineRule({ id: 'probe/types', description: 'Types must pass.' });
+
+  const check = commands({
+    mode: 'parallel',
+    maxAtOnce: 2,
+    entries: [
+      { rule: lint, command: 'npm', args: ['run', 'lint'], label: 'lint' },
+      { rule: types, command: '/usr/local/bin/tsc', args: ['--noEmit'] },
+    ],
+  });
+
+  assert.equal(check.description, 'run 2 commands: lint, tsc');
+});

--- a/tests/gate-checks.test.ts
+++ b/tests/gate-checks.test.ts
@@ -8,7 +8,7 @@ import { readSources, listPaths } from '../gates/support/sources.ts';
 import { node, stripTypes, tsc } from '../gates/support/node.ts';
 import { effectBoundaries } from '../gates/checks/effect-boundaries.ts';
 import { repositoryPolicy } from '../gates/checks/repository-policy.ts';
-import { nodeTestArgs, nodeTestSuite } from '../gates/checks/node-test-suite.ts';
+import { nodeTestSuite } from '../gates/checks/node-test-suite.ts';
 import { withWorkspace } from './helpers/workspace.ts';
 
 const ruleA = defineRule({ id: 'probe/a', description: 'Rule A.' });
@@ -168,14 +168,15 @@ test('node helpers build the runtime arguments a Gate needs', () => {
   assert.deepEqual(tsc('--noEmit'), ['node_modules/typescript/bin/tsc', '--noEmit']);
 });
 
-test('nodeTestArgs runs the matching files with a JUnit report destination', async () => {
+test('nodeTestSuite runs the matching files with a JUnit report destination', async () => {
   await withWorkspace(async root => {
     await mkdir(join(root, 'tests'), { recursive: true });
     await writeFile(join(root, 'tests/one.test.ts'), '\n', 'utf8');
     await writeFile(join(root, 'tests/two.test.ts'), '\n', 'utf8');
     await writeFile(join(root, 'tests/helper.ts'), '\n', 'utf8');
 
-    const args = nodeTestArgs('tests/**/*.test.ts', { root, reportFile: '/tmp/report.xml' });
+    const built = nodeTestSuite({ files: 'tests/**/*.test.ts' });
+    const args = built.argsFor?.({ root, reportFile: '/tmp/report.xml' }) ?? [];
 
     assert.ok(args.includes('--test'));
     assert.ok(args.includes('--test-reporter=junit'));
@@ -187,9 +188,14 @@ test('nodeTestArgs runs the matching files with a JUnit report destination', asy
   });
 });
 
-test('nodeTestSuite describes itself for redproof describe', () => {
-  const built = nodeTestSuite({ files: 'tests/**/*.test.ts' });
-  assert.match(built.description, /Node test suite/);
+test('nodeTestSuite names the pattern it runs, so the description cannot drift', () => {
+  const built = nodeTestSuite({ files: 'tests/unit/**/*.spec.ts' });
+
+  assert.equal(
+    built.description,
+    'run tests/unit/**/*.spec.ts under node --test with a JUnit report',
+  );
+  assert.deepEqual(built.plan, { command: process.execPath });
 });
 
 // ---------- effectBoundaries ----------


### PR DESCRIPTION
## Problem

A command runner returned an object with two keys.

```text
keys exposed: description, run
```

The command, the arguments, and the environment stayed inside a closure. Nothing
outside could see what a Gate would execute.

Three faults followed.

**The default description carried a machine path.** With `command:
process.execPath` the description became:

```text
"run /Users/schalermthai/.nvm/versions/node/v24.16.0/bin/node"
```

That string reaches `redproof describe` and the JSON and SARIF reports. Two
people running the same Gate got different reports, and neither said what ran.

**`describe` could not name a command group.**

```text
Gate: static-contracts
Check:
  run 3 commands
```

Which three? Redproof exists so a reader can see what a Gate claims. Here the
Gate claimed nothing checkable.

**A hand-written description could drift.** Change the arguments and the
sentence stays. It is a claim with no gate behind it.

## Fix

`TestRunner` gains two optional fields.

```ts
export type CommandPlan = {
  readonly command: string;
  /** Absent when the arguments are computed from the run context. */
  readonly args?: readonly string[];
};
```

`plan` answers "what will this run?" without a context, which is what `describe`
needs. `argsFor` answers "what did it run for this context?", which is the only
way to see a computed argument list. Both are optional, so no existing runner
breaks.

Both default descriptions now come from the real command line, using the base
name of the command:

```text
before   "run /Users/schalermthai/.nvm/versions/node/v24.16.0/bin/node"
after    "run node --test"

before   "run 3 commands"
after    "run 3 commands: workspace TypeScript, documentation examples,
          documentation fragment budget"
```

An explicit `description` still wins.

`command()` and `commands()` also move to their own document. They build a Check
from an executable, and they sat inside `docs/composition.md` directly above the
Adapter section, so a reader met them as Adapter material. An Adapter is for a
tool that brings its own policy model. `docs/commands.md` now holds the API,
exit-code policy, command groups, and what a Check reports about itself.
`composition.md`, `adapters.md`, the README, and the tutorials index point at
it.

The repository's own `test-health` Gate stops working around the old shape.
`gates/checks/node-test-suite.ts` had an extracted `nodeTestArgs` function,
which existed only because the runner hid its arguments. That is deleted, and
the test calls `argsFor` directly.

Its description was also a hand-written sentence claiming the suite was
complete. Nothing checked that word. The description is now built from the file
pattern, so `redproof describe` names what actually runs:

```text
before   run the complete Node test suite with a structured JUnit report
after    run tests/**/*.test.ts under node --test with a JUnit report
```

## Verification

`npm run check` exits 0. 167 tests, 167 pass, 0 fail. `npm run verify:package`
exits 0 with 50 PASS. The self-hosted suite reports 4 Gates passed and 20 Rules
held. 15 documentation examples type-check across 10 documents, and the
fragment count stays at 39 of 39.

Five tests are new, and each was proven able to fail. Every break reddened only
the tests that guard it:

```text
description returns to the raw command path   1 red   the base-name test
the runner stops exposing plan                3 red   all three plan tests
the runner stops exposing argsFor             1 red   the computed-args test
the Check description drops its arguments     1 red   the invocation test
the group stops naming its commands           1 red   the group naming test
```

All five were restored, and both files are green at 33 of 33.

Two more in the self-hosted Gate, for the same reason:

```text
the description is hard-coded again        1 red   the drift test
the runner globs a pattern it was not given 1 red   the arguments test
```

The new documentation example is a checked block, not a fragment. It compiles,
and the fragment budget was not raised to make room for it. The pointer left in
`composition.md` carries no code block, for the same reason.

The new document is covered by the repository's own docs-links Rule. A broken
link was planted in it, and the Gate named the file and the target:

```text
FAIL  gates/repository-policy.ts > docs-relative-links-resolve
  docs/commands.md points to missing docs/no-such-file.md.
```

The link was removed and `redproof check` exits 0 again.

## Note on visible output

Anyone who did not set a `description` sees a different string in `redproof
describe` and in their reports. That is the fix, not a side effect.
