### PR TITLE
Scan legacy in the architecture example

### DIFF
--- a/docs/legacy-modernization.md
+++ b/docs/legacy-modernization.md
@@ -377,7 +377,7 @@ import { defineGate, defineProofs, mutate, proof } from 'redproof';
 
 const adapter = dependencyCruiser({
   configFile: '.dependency-cruiser.cjs',
-  files: ['src'],
+  files: ['src', 'legacy'],
   rules: {
     domainNoLegacyDb: 'domain-no-legacy-db',
     noReverseDependency: 'no-reverse-dependency',


### PR DESCRIPTION
## Problem

The architecture example in `docs/legacy-modernization.md` sets `files: ['src']`.

Its R2 proof appends an import to `legacy/billing/invoice.js`. dependency-cruiser reports a violation only in a file it scans. It reads the listed roots, then follows imports outward. Nothing in `src` imports `legacy`, so that file was never cruised.

The `no-reverse-dependency` Rule could never fail. A reader who copied the example got a Gate that can only print success. That is the failure the guide exists to prevent.

## Fix

`files: ['src', 'legacy']`.

## Verification

A reproduction mirrors the example: `src/domain/customer.ts`, `legacy/db/connection.js`, `legacy/billing/invoice.js`, and a `.dependency-cruiser.cjs` holding both rules. A driver calls the real adapter from `packages/dependency-cruiser/src/index.ts` over four states.

```text
--- clean (no mutation) ---
files=[src]           inspected=1  verdict=pass  breaches=-
files=[src, legacy]   inspected=3  verdict=pass  breaches=-

--- R2 mutation on legacy/billing/invoice.js ---
files=[src]           inspected=1  verdict=pass  breaches=-                       BROKEN
files=[src, legacy]   inspected=3  verdict=fail  breaches=no-reverse-dependency    FIXED

--- R1 mutation on src/domain/customer.ts ---
files=[src]           inspected=2  verdict=fail  breaches=domain-no-legacy-db
files=[src, legacy]   inspected=3  verdict=fail  breaches=domain-no-legacy-db
```

Read the `inspected` column. With `files: ['src']` the scanner cruised 1 file. The mutated file was never read.

Rows 3 and 4 are the red proof. The R2 proof expects FAIL. Before the fix it got PASS, which is the same verdict the clean state returns. After the fix it gets FAIL and names the right Rule.

Rows 1 and 2 show the GREEN proof still holds. Rows 5 and 6 show Rule R1 is unaffected.

Repository gates:

```text
npm run docs:typecheck   All documentation examples type-check. 15 checked, 39 fragments.
npm run self:check       4 Gates passed, 20 Rules held, 6.72s
```

The fragment count stays at 39. The budget is untouched.
