### PR TITLE
Report a bad reporter option as a usage error

### DIFF
--- a/packages/redproof/src/cli/core/arguments.ts
+++ b/packages/redproof/src/cli/core/arguments.ts
@@ -1,4 +1,4 @@
-import { parseReporterArgs, type ReporterSpec } from '../../reporter/core/index.ts';
+import { parseReporterArgs, ReporterArgumentError, type ReporterSpec } from '../../reporter/core/index.ts';
 
 export const HELP = `Usage: redproof [command] [gate files...] [options]
 
@@ -95,12 +95,17 @@ export function parseArguments(argv: readonly string[], stdoutIsTty: boolean): C
   const command = argv[0] ?? 'check';
   if (!isCommand(command)) return { kind: 'usage-error', message: `Unknown command: ${command}` };
 
-  const reporters = command === 'describe' ? [] : parseReporterArgs(argv);
+  let reporters: readonly ReporterSpec[];
+  try {
+    reporters = command === 'describe' ? [] : parseReporterArgs(argv);
+  } catch (error) {
+    if (!(error instanceof ReporterArgumentError)) throw error;
+    return { kind: 'usage-error', message: error.message };
+  }
   if (command === 'prove') {
-    for (const spec of reporters) {
-      if (spec.name !== 'default' && spec.name !== 'json') {
-        throw new Error(`Reporter ${spec.name} does not support the prove command.`);
-      }
+    const unsupported = reporters.find(spec => spec.name !== 'default' && spec.name !== 'json');
+    if (unsupported) {
+      return { kind: 'usage-error', message: `Reporter ${unsupported.name} does not support the prove command.` };
     }
   }
 

--- a/packages/redproof/src/index.ts
+++ b/packages/redproof/src/index.ts
@@ -144,6 +144,7 @@ export {
   formatRun,
   formatSarifRun,
   parseReporterArgs,
+  ReporterArgumentError,
   renderCheckReporter,
   renderProveReporter,
   renderRun,

--- a/packages/redproof/src/reporter/core/arguments.ts
+++ b/packages/redproof/src/reporter/core/arguments.ts
@@ -7,6 +7,9 @@ export type ReporterSpec = {
   readonly outputFile?: string;
 };
 
+/** A reporter option the user got wrong. The CLI reports it as a usage error, not a crash. */
+export class ReporterArgumentError extends Error {}
+
 const names = new Set(['default', 'compact', 'json', 'sarif']);
 
 function valueAfter(args: readonly string[], index: number): string | undefined {
@@ -17,8 +20,8 @@ function parseReporterValue(value: string): ReporterSpec {
   const colon = value.indexOf(':');
   const name = colon < 0 ? value : value.slice(0, colon);
   const outputFile = colon < 0 ? undefined : value.slice(colon + 1);
-  if (!names.has(name)) throw new Error(`Unknown reporter: ${name}`);
-  if (colon >= 0 && !outputFile) throw new Error(`Reporter ${name} output path cannot be empty.`);
+  if (!names.has(name)) throw new ReporterArgumentError(`Unknown reporter: ${name}`);
+  if (colon >= 0 && !outputFile) throw new ReporterArgumentError(`Reporter ${name} output path cannot be empty.`);
   return {
     name: name as ReporterSpec['name'],
     ...(outputFile ? { outputFile } : {}),
@@ -34,33 +37,33 @@ export function parseReporterArgs(args: readonly string[]): readonly ReporterSpe
     const arg = args[index]!;
     if (arg === '--reporter') {
       const value = valueAfter(args, index);
-      if (!value) throw new Error('--reporter requires a value.');
+      if (!value) throw new ReporterArgumentError('--reporter requires a value.');
       reporters.push(parseReporterValue(value));
       index++;
     } else if (arg.startsWith('--reporter=')) {
       reporters.push(parseReporterValue(arg.slice('--reporter='.length)));
     } else if (arg === '--outputFile') {
       outputFile = valueAfter(args, index);
-      if (!outputFile) throw new Error('--outputFile requires a value.');
+      if (!outputFile) throw new ReporterArgumentError('--outputFile requires a value.');
       index++;
     } else if (arg.startsWith('--outputFile=')) {
       outputFile = arg.slice('--outputFile='.length);
-      if (!outputFile) throw new Error('--outputFile requires a value.');
+      if (!outputFile) throw new ReporterArgumentError('--outputFile requires a value.');
     }
   }
 
   if (reporters.length === 0) reporters.push({ name: 'default' });
   if (outputFile) {
     if (reporters.length !== 1) {
-      throw new Error('--outputFile can only be used when exactly one reporter is selected. Use --reporter=name:path for multiple reporters.');
+      throw new ReporterArgumentError('--outputFile can only be used when exactly one reporter is selected. Use --reporter=name:path for multiple reporters.');
     }
-    if (reporters[0]!.outputFile) throw new Error('Output file was specified twice.');
+    if (reporters[0]!.outputFile) throw new ReporterArgumentError('Output file was specified twice.');
     reporters[0] = { ...reporters[0]!, outputFile };
   }
 
   const stdoutCount = reporters.filter(item => !item.outputFile).length;
   if (stdoutCount > 1) {
-    throw new Error('At most one reporter may write to stdout. Give additional reporters an output path, for example --reporter=json:.redproof/results.json.');
+    throw new ReporterArgumentError('At most one reporter may write to stdout. Give additional reporters an output path, for example --reporter=json:.redproof/results.json.');
   }
 
   return reporters;

--- a/tests/cli.core.test.ts
+++ b/tests/cli.core.test.ts
@@ -60,10 +60,23 @@ test('an unknown command is a usage error, and describe takes no reporter', () =
 
 test('prove accepts only the default and json reporters', () => {
   assert.equal(parseArguments(['prove', '--reporter=json'], false).kind, 'run');
-  assert.throws(
-    () => parseArguments(['prove', '--reporter=sarif'], false),
-    /Reporter sarif does not support the prove command\./,
-  );
+  assert.deepEqual(parseArguments(['prove', '--reporter=sarif'], false), {
+    kind: 'usage-error',
+    message: 'Reporter sarif does not support the prove command.',
+  });
+});
+
+test('a bad reporter option is a usage error, never a crash', () => {
+  assert.deepEqual(parseArguments(['check', '--reporter=bogus'], false), {
+    kind: 'usage-error',
+    message: 'Unknown reporter: bogus',
+  });
+  assert.deepEqual(parseArguments(['check', '--reporter'], false), {
+    kind: 'usage-error',
+    message: '--reporter requires a value.',
+  });
+  assert.equal(parseArguments(['check', '--reporter=json', '--reporter=sarif'], false).kind, 'usage-error');
+  assert.equal(parseArguments(['check', '--reporter=json:'], false).kind, 'usage-error');
 });
 
 test('the missing-config message names every file it looked for', () => {

--- a/tests/reporter/cli.test.ts
+++ b/tests/reporter/cli.test.ts
@@ -68,6 +68,31 @@ test('CLI reports a missing config value without an internal stack trace', () =>
   assert.doesNotMatch(result.stderr, /node:path|at main|ERR_/);
 });
 
+test('CLI rejects a bad reporter option without an internal stack trace', () => {
+  const result = spawnSync(process.execPath, [
+    '--disable-warning=ExperimentalWarning',
+    '--experimental-strip-types',
+    'packages/redproof/src/cli.ts',
+    'check',
+    '--reporter=bogus',
+  ], { cwd: resolve('.'), encoding: 'utf8' });
+
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /^Unknown reporter: bogus\n$/);
+  assert.doesNotMatch(result.stderr, /at |ERR_/);
+
+  const prove = spawnSync(process.execPath, [
+    '--disable-warning=ExperimentalWarning',
+    '--experimental-strip-types',
+    'packages/redproof/src/cli.ts',
+    'prove',
+    '--reporter=sarif',
+  ], { cwd: resolve('.'), encoding: 'utf8' });
+
+  assert.equal(prove.status, 2);
+  assert.match(prove.stderr, /^Reporter sarif does not support the prove command\.\n$/);
+});
+
 test('CLI discovers an ESM config in a CommonJS project', () => {
   const result = spawnSync(process.execPath, [
     '--disable-warning=ExperimentalWarning',


### PR DESCRIPTION
## Problem

A wrong reporter name, a missing `--reporter` value, two reporters on stdout, or a `prove` reporter that `prove` does not support threw a plain `Error` out of argument parsing. The CLI printed a stack trace and exited with 1. Every other usage mistake prints one line and exits with 2.

```text
$ redproof check --reporter=bogus
file:///.../reporter/core/arguments.ts:20
  if (!names.has(name)) throw new Error(`Unknown reporter: ${name}`);
                        ^
Error: Unknown reporter: bogus
    at parseReporterValue (...)
```

## Fix

`parseReporterArgs` throws `ReporterArgumentError`, a named subclass of `Error`, at all 8 sites. The CLI parser catches it and returns a usage-error invocation. The `prove` reporter check returns a usage error directly instead of throwing. The shell already prints a usage error alone and exits with 2. `ReporterArgumentError` is exported for programmatic callers of `parseReporterArgs`.

```text
$ redproof check --reporter=bogus
Unknown reporter: bogus
$ echo $?
2
```

## Verification

`npm run check` passes: 198 tests, 4 Gates with 22 Rules held, 31 proofs at their expected colour.

Red proof. Removing the catch in the CLI parser fails "a bad reporter option is a usage error, never a crash" and the end-to-end test "CLI rejects a bad reporter option without an internal stack trace". Restored, both pass.