### PR TITLE
State the composition dependency rule as an allowlist

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -20,7 +20,7 @@ module.exports = {
     {
       name: 'core-no-shell',
       severity: 'error',
-      comment: 'The functional core cannot depend on orchestration or presentation.',
+      comment: 'The functional core cannot depend on orchestration or presentation. A context barrel carries its shell, so a core uses core/index.ts instead. The domain barrel is types only.',
       from: { path: '^packages/redproof/src/(?:domain|[^/]+/core)/' },
       to: {
         path: '^packages/redproof/src/(?:[^/]+/shell/|[^/]+/index[.]ts$|index[.]ts$|cli[.]ts$)',
@@ -64,9 +64,12 @@ module.exports = {
     {
       name: 'composition-no-runtime-or-reporters',
       severity: 'error',
-      comment: 'Composition cannot depend on runtime orchestration or presentation.',
+      comment: 'Composition may depend only on itself, the domain, and inspection. Every other context is downstream of it.',
       from: { path: '^packages/redproof/src/composition/' },
-      to: { path: '^packages/redproof/src/(?:(?:cli|command|project|proof|workspace|run|reporter)/|cli[.]ts$)' },
+      to: {
+        path: '^packages/redproof/src/',
+        pathNot: '^packages/redproof/src/(?:composition|domain|inspect)/',
+      },
     },
     {
       name: 'adapters-public-core-api-only',


### PR DESCRIPTION
## Problem

`core-no-shell` exempts `domain/index.ts` and its comment does not say why. `composition-no-runtime-or-reporters` names the forbidden contexts one by one: `cli`, `command`, `project`, `proof`, `workspace`, `run`, `reporter`. A new context must be added by hand, or the Rule silently stops covering it.

## Fix

The `core-no-shell` comment now says a context barrel carries its shell, so a core uses `core/index.ts`, and the domain barrel is types only.

`composition-no-runtime-or-reporters` is now an allowlist. Composition may import only `composition`, `domain`, and `inspect`. That states the dependency direction and needs no change when a context is added. No Rule id, Gate file, or proof changed.

## Verification

The architecture Gate holds with 12 Rules. All 13 of its proofs stay at their expected colour, including "keeps the imperative shell out of the functional core" and "keeps declarative composition independent of runtime orchestration".

Red proof of the allowlist. An import of `support/index.ts` planted in `composition/core/options.ts` breaches the composition Rule. The old list never named `support`. Restored, the Gate holds.