### PR TITLE
Say why a proof was judged as it was

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,10 +201,11 @@ redproof prove
 
 ```text
 ✓ no-todo / detects a TODO comment expected=red actual=fail
+    breached source/no-todo: src/checkout.ts:12: TODO left in source
 ✓ no-todo / accepts clean source expected=green actual=pass
 ```
 
-The RED proof temporarily adds a TODO, runs the real Check, confirms `source/no-todo` was breached, then restores the workspace.
+The RED proof temporarily adds a TODO, runs the real Check, confirms `source/no-todo` was breached, then restores the workspace. The second line names the Rule that breached and what the Check said. A proof that did not prove says why on that line: the wrong Rule breached, the Check passed, or the target was already breached before the mutation.
 
 The GREEN proof confirms that clean source passes.
 

--- a/packages/redproof/schema/prove-report-v1.schema.json
+++ b/packages/redproof/schema/prove-report-v1.schema.json
@@ -3,24 +3,106 @@
   "$id": "redproof-prove-report-v1",
   "title": "Redproof prove report v1",
   "type": "object",
-  "required": ["version", "command", "status", "proofs"],
+  "required": [
+    "version",
+    "command",
+    "status",
+    "proofs"
+  ],
   "properties": {
-    "version": { "const": 1 },
-    "command": { "const": "prove" },
-    "status": { "enum": ["passed", "failed"] },
+    "version": {
+      "const": 1
+    },
+    "command": {
+      "const": "prove"
+    },
+    "status": {
+      "enum": [
+        "passed",
+        "failed"
+      ]
+    },
     "proofs": {
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["gate", "proof", "expected", "status", "workerPid"],
+        "required": [
+          "gate",
+          "proof",
+          "expected",
+          "status",
+          "workerPid"
+        ],
         "properties": {
-          "gate": { "type": "string" },
-          "proof": { "type": "string" },
-          "expected": { "enum": ["red", "green", "refuse"] },
-          "status": { "enum": ["proved", "not-proved", "infrastructure-error"] },
-          "workerPid": { "type": "integer" },
-          "check": { "type": "object" },
-          "error": { "type": "object" }
+          "gate": {
+            "type": "string"
+          },
+          "proof": {
+            "type": "string"
+          },
+          "expected": {
+            "enum": [
+              "red",
+              "green",
+              "refuse"
+            ]
+          },
+          "status": {
+            "enum": [
+              "proved",
+              "not-proved",
+              "infrastructure-error"
+            ]
+          },
+          "workerPid": {
+            "type": "integer"
+          },
+          "reason": {
+            "type": "object",
+            "required": [
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "enum": [
+                  "proved",
+                  "verdict-mismatch",
+                  "target-rule-not-breached",
+                  "target-already-breached"
+                ]
+              },
+              "target": {
+                "type": "string"
+              },
+              "breached": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "expected": {
+                "enum": [
+                  "pass",
+                  "fail",
+                  "refuse"
+                ]
+              },
+              "actual": {
+                "enum": [
+                  "pass",
+                  "fail",
+                  "refuse"
+                ]
+              }
+            },
+            "additionalProperties": false
+          },
+          "check": {
+            "type": "object"
+          },
+          "error": {
+            "type": "object"
+          }
         },
         "additionalProperties": false
       }

--- a/packages/redproof/src/index.ts
+++ b/packages/redproof/src/index.ts
@@ -114,6 +114,7 @@ export { runGate, runProof } from './proof/index.ts';
 export type {
   CompletedProofOutcome,
   InfrastructureProofOutcome,
+  ProofEvaluation,
   ProofInfrastructureError,
   ProofOutcome,
 } from './proof/index.ts';

--- a/packages/redproof/src/proof/core/evaluation.ts
+++ b/packages/redproof/src/proof/core/evaluation.ts
@@ -1,7 +1,7 @@
 import type { CheckResult, Proof, RuleRef } from '../../domain/index.ts';
 
 export type ProofEvaluation =
-  | { readonly kind: 'proved' }
+  | { readonly kind: 'proved'; readonly target?: RuleRef }
   | {
       readonly kind: 'verdict-mismatch';
       readonly expected: 'fail' | 'pass' | 'refuse';
@@ -9,6 +9,11 @@ export type ProofEvaluation =
     }
   | {
       readonly kind: 'target-rule-not-breached';
+      readonly target: RuleRef;
+      readonly breached: readonly RuleRef[];
+    }
+  | {
+      readonly kind: 'target-already-breached';
       readonly target: RuleRef;
       readonly breached: readonly RuleRef[];
     };
@@ -46,6 +51,7 @@ export function evaluateProof(proof: Proof, result: CheckResult): ProofEvaluatio
         breached,
       };
     }
+    return { kind: 'proved', target: proof.target };
   }
 
   return { kind: 'proved' };

--- a/packages/redproof/src/proof/core/index.ts
+++ b/packages/redproof/src/proof/core/index.ts
@@ -1,3 +1,4 @@
+export type { ProofEvaluation } from './evaluation.ts';
 export type {
   CompletedProofOutcome,
   InfrastructureProofOutcome,

--- a/packages/redproof/src/proof/core/lifecycle.ts
+++ b/packages/redproof/src/proof/core/lifecycle.ts
@@ -46,12 +46,14 @@ export function baselineOutcome(
   baseline: CheckResult,
   workerPid: number,
 ): CompletedProofOutcome {
+  const breached = baseline.verdict === 'fail' ? baseline.breaches.map(item => item.rule) : [];
   return {
     status: 'completed',
     gate: gate.id,
     proof: proof.name,
     expected: proof.expected,
     ok: false,
+    reason: { kind: 'target-already-breached', target: proof.expected === 'red' ? proof.target : '', breached },
     result: baseline,
     workerPid,
   };
@@ -63,12 +65,14 @@ export function completedOutcome(
   result: CheckResult,
   workerPid: number,
 ): CompletedProofOutcome {
+  const reason = evaluateProof(proof, result);
   return {
     status: 'completed',
     gate: gate.id,
     proof: proof.name,
     expected: proof.expected,
-    ok: proofSucceeded(evaluateProof(proof, result)),
+    ok: proofSucceeded(reason),
+    reason,
     result,
     workerPid,
   };

--- a/packages/redproof/src/proof/core/outcome.ts
+++ b/packages/redproof/src/proof/core/outcome.ts
@@ -1,4 +1,5 @@
 import type { CheckResult, Proof } from '../../domain/index.ts';
+import type { ProofEvaluation } from './evaluation.ts';
 
 export type ProofInfrastructureError = {
   readonly code:
@@ -16,6 +17,8 @@ export type CompletedProofOutcome = {
   readonly proof: string;
   readonly expected: Proof['expected'];
   readonly ok: boolean;
+  /** How the proof was judged. `ok` is `reason.kind === 'proved'`. */
+  readonly reason: ProofEvaluation;
   readonly result: CheckResult;
   readonly workerPid: number;
 };

--- a/packages/redproof/src/reporter/core/json.ts
+++ b/packages/redproof/src/reporter/core/json.ts
@@ -1,5 +1,7 @@
+import type { CheckResult } from '../../domain/index.ts';
+import type { ProofEvaluation } from '../../proof/core/index.ts';
 import type { CheckProjectRun, ProveProjectRun } from '../../run/core/index.ts';
-import { buildJsonCheckReport } from './check-report.ts';
+import { buildJsonCheckReport, type JsonBreachV1, type JsonDiagnosticV1 } from './check-report.ts';
 
 export type JsonReporterOptions = {
   readonly pretty?: boolean;
@@ -15,8 +17,12 @@ export type JsonProofOutcomeV1 = {
   readonly expected: 'red' | 'green' | 'refuse';
   readonly status: 'proved' | 'not-proved' | 'infrastructure-error';
   readonly workerPid: number;
+  /** How the proof was judged. Absent on an infrastructure error. */
+  readonly reason?: ProofEvaluation;
   readonly check?: {
     readonly verdict: 'pass' | 'fail' | 'refuse';
+    readonly breaches?: readonly JsonBreachV1[];
+    readonly refusal?: JsonDiagnosticV1;
   };
   readonly error?: {
     readonly code: string;
@@ -32,6 +38,38 @@ export type JsonProveReportV1 = {
   readonly proofs: readonly JsonProofOutcomeV1[];
 };
 
+function jsonCheck(result: CheckResult): NonNullable<JsonProofOutcomeV1['check']> {
+  if (result.verdict === 'fail') {
+    return {
+      verdict: 'fail',
+      breaches: result.breaches.map(item => ({
+        rule: item.rule,
+        code: item.code,
+        message: item.message,
+        location: item.location,
+        ...(item.comparison ? { comparison: item.comparison } : {}),
+        ...(item.detail ? { detail: item.detail } : {}),
+        ...(item.hint ? { hint: item.hint } : {}),
+      })),
+    };
+  }
+  if (result.verdict === 'refuse') {
+    const why = result.why;
+    return {
+      verdict: 'refuse',
+      refusal: {
+        code: why.code,
+        message: why.message,
+        location: why.location,
+        ...(why.comparison ? { comparison: why.comparison } : {}),
+        ...(why.detail ? { detail: why.detail } : {}),
+        ...(why.hint ? { hint: why.hint } : {}),
+      },
+    };
+  }
+  return { verdict: 'pass' };
+}
+
 export function buildJsonProveReport(run: ProveProjectRun): JsonProveReportV1 {
   return {
     version: 1,
@@ -45,7 +83,8 @@ export function buildJsonProveReport(run: ProveProjectRun): JsonProveReportV1 {
         ? 'infrastructure-error'
         : outcome.ok ? 'proved' : 'not-proved',
       workerPid: outcome.workerPid,
-      ...(outcome.result ? { check: { verdict: outcome.result.verdict } } : {}),
+      ...(outcome.status === 'completed' ? { reason: outcome.reason } : {}),
+      ...(outcome.result ? { check: jsonCheck(outcome.result) } : {}),
       ...(outcome.status === 'error'
         ? {
             error: {

--- a/packages/redproof/src/reporter/core/terminal.ts
+++ b/packages/redproof/src/reporter/core/terminal.ts
@@ -1,7 +1,7 @@
 import { relative } from 'node:path';
 import type { CheckResult, Diagnostic, Rule } from '../../domain/index.ts';
 import type { GateDescription } from '../../project/core/index.ts';
-import type { ProofOutcome } from '../../proof/core/index.ts';
+import type { CompletedProofOutcome, ProofOutcome } from '../../proof/core/index.ts';
 import type { CheckProjectRun, GateRun } from '../../run/core/index.ts';
 import { buildGateReportModel, summarizeGateReports, type RunSummary } from './model.ts';
 
@@ -251,13 +251,45 @@ export function formatCheck(gate: string, result: CheckResult): string {
   return `FAIL ${gate}\n${result.breaches.map(item => `  ${item.rule}: ${item.message}`).join('\n')}`;
 }
 
+function checkOutcomeDetail(result: CheckResult, rule?: string): string {
+  if (result.verdict === 'refuse') return `${result.why.code}: ${result.why.message}`;
+  if (result.verdict === 'pass') return '';
+  const first = result.breaches.find(item => rule === undefined || item.rule === rule) ?? result.breaches[0];
+  return `${first.rule}: ${first.message}`;
+}
+
+/** One line that says why a completed proof was judged as it was. Empty when there is nothing to add. */
+export function proofReason(outcome: CompletedProofOutcome): string {
+  const reason = outcome.reason;
+  const result = outcome.result;
+
+  if (reason.kind === 'proved') {
+    if (outcome.expected === 'red') return `breached ${checkOutcomeDetail(result, reason.target)}`;
+    if (outcome.expected === 'refuse') return `refused ${checkOutcomeDetail(result)}`;
+    return '';
+  }
+  if (reason.kind === 'target-rule-not-breached') {
+    return `target ${reason.target} not breached; breached ${reason.breached.join(', ')}`;
+  }
+  if (reason.kind === 'target-already-breached') {
+    return `target ${reason.target} was already breached before the mutation; breached ${reason.breached.join(', ')}`;
+  }
+  const detail = checkOutcomeDetail(result);
+  if (result.verdict === 'pass' && reason.expected === 'fail') {
+    return `expected ${reason.expected}, got ${reason.actual}; the mutation did not reach what the Rule guards`;
+  }
+  return `expected ${reason.expected}, got ${reason.actual}${detail ? `: ${detail}` : ''}`;
+}
+
 export function formatProof(outcome: ProofOutcome): string {
   const mark = outcome.ok ? '✓' : '✗';
   if (outcome.status === 'error') {
     const actual = outcome.result ? ` actual=${outcome.result.verdict}` : '';
     return `${mark} ${outcome.gate} / ${outcome.proof} expected=${outcome.expected}${actual} error=${outcome.error.code}\n  ${outcome.error.message}${outcome.error.detail ? `\n  ${outcome.error.detail}` : ''}`;
   }
-  return `${mark} ${outcome.gate} / ${outcome.proof} expected=${outcome.expected} actual=${outcome.result.verdict}`;
+  const line = `${mark} ${outcome.gate} / ${outcome.proof} expected=${outcome.expected} actual=${outcome.result.verdict}`;
+  const reason = proofReason(outcome);
+  return reason ? `${line}\n    ${reason}` : line;
 }
 
 function indentDescription(text: string): string[] {

--- a/tests/proof.core.test.ts
+++ b/tests/proof.core.test.ts
@@ -47,6 +47,7 @@ test('restoration failure replaces proof success and prevents copy reuse', () =>
     proof: 'p',
     expected: 'green',
     ok: true,
+    reason: { kind: 'proved' },
     result,
     workerPid: 10,
   };

--- a/tests/proof.test.ts
+++ b/tests/proof.test.ts
@@ -111,6 +111,7 @@ test('RED proof proves when its mutation breaches the target, then restores the 
 
   assert.equal(outcome.status, 'completed');
   assert.equal(outcome.ok, true);
+  assert.deepEqual(outcome.status === 'completed' && outcome.reason, { kind: 'proved', target: 'r1' });
   assert.equal(outcome.result?.verdict, 'fail');
   assert.deepEqual(state.log, ['apply r1', 'undo r1']);
   assert.deepEqual(state.breached, []);
@@ -122,6 +123,7 @@ test('RED proof does not pass when the Gate fails for another Rule', async () =>
 
   assert.equal(outcome.status, 'completed');
   assert.equal(outcome.ok, false);
+  assert.deepEqual(outcome.status === 'completed' && outcome.reason, { kind: 'target-rule-not-breached', target: 'r1', breached: ['r2'] });
   assert.equal(outcome.result?.verdict, 'fail');
   assert.deepEqual(state.log, ['apply r2', 'undo r2']);
 });
@@ -132,6 +134,7 @@ test('RED proof does not pass when its target was already breached before mutati
 
   assert.equal(outcome.status, 'completed');
   assert.equal(outcome.ok, false);
+  assert.deepEqual(outcome.status === 'completed' && outcome.reason, { kind: 'target-already-breached', target: 'r1', breached: ['r1'] });
   assert.equal(outcome.result?.verdict, 'fail');
   assert.deepEqual(state.log, [], 'the mutation must never be applied');
   assert.equal(state.contexts.length, 1, 'only the baseline Check runs');

--- a/tests/reporter.core.test.ts
+++ b/tests/reporter.core.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { breach, counting, defineAdapter, defineGate, fail, pass, type CheckResult, type Scan } from 'redproof';
+import { breach, counting, defineAdapter, defineGate, fail, formatProof, pass, refuse, type CheckResult, type ProofOutcome, type Scan } from 'redproof';
 import type { CheckProjectRun } from '../packages/redproof/src/run/core/run.ts';
 import { renderRun } from '../packages/redproof/src/reporter/core/terminal.ts';
 
@@ -54,4 +54,43 @@ test('a diagnostic without a line never asks for source', () => {
 
   assert.match(output, / ❯ src\/a\.ts\n\n   R1 breached/);
   assert.doesNotMatch(output, /ignored/);
+});
+
+function completed(expected: 'red' | 'green' | 'refuse', reason: Extract<ProofOutcome, { status: 'completed' }>['reason'], result: CheckResult): ProofOutcome {
+  return { status: 'completed', gate: 'lint', proof: 'a var is flagged', expected, ok: reason.kind === 'proved', reason, result, workerPid: 1 };
+}
+
+test('a proof line says why it was judged as it was', () => {
+  const noVar = breach('lint/no-var', { code: 'no-var', message: 'src/a.mjs:3: use let or const', location: null });
+  const noLet = breach('lint/no-let', { code: 'no-let', message: 'src/a.mjs:4: use const', location: null });
+
+  assert.equal(
+    formatProof(completed('red', { kind: 'proved', target: 'lint/no-var' }, fail(scan, [noLet, noVar]))),
+    '✓ lint / a var is flagged expected=red actual=fail\n    breached lint/no-var: src/a.mjs:3: use let or const',
+  );
+  assert.equal(
+    formatProof(completed('red', { kind: 'target-rule-not-breached', target: 'lint/no-var', breached: ['lint/no-let'] }, fail(scan, [noLet]))),
+    '✗ lint / a var is flagged expected=red actual=fail\n    target lint/no-var not breached; breached lint/no-let',
+  );
+  assert.equal(
+    formatProof(completed('red', { kind: 'verdict-mismatch', expected: 'fail', actual: 'pass' }, pass(scan))),
+    '✗ lint / a var is flagged expected=red actual=pass\n    expected fail, got pass; the mutation did not reach what the Rule guards',
+  );
+  assert.equal(
+    formatProof(completed('red', { kind: 'target-already-breached', target: 'lint/no-var', breached: ['lint/no-var'] }, fail(scan, [noVar]))),
+    '✗ lint / a var is flagged expected=red actual=fail\n    target lint/no-var was already breached before the mutation; breached lint/no-var',
+  );
+  const refused = refuse(scan, { code: 'unavailable', message: 'No input', location: null });
+  assert.equal(
+    formatProof(completed('refuse', { kind: 'proved' }, refused)),
+    '✓ lint / a var is flagged expected=refuse actual=refuse\n    refused unavailable: No input',
+  );
+  assert.equal(
+    formatProof(completed('green', { kind: 'verdict-mismatch', expected: 'pass', actual: 'refuse' }, refused)),
+    '✗ lint / a var is flagged expected=green actual=refuse\n    expected pass, got refuse: unavailable: No input',
+  );
+  assert.equal(
+    formatProof(completed('green', { kind: 'proved' }, pass(scan))),
+    '✓ lint / a var is flagged expected=green actual=pass',
+  );
 });

--- a/tests/reporter/prove-json.test.ts
+++ b/tests/reporter/prove-json.test.ts
@@ -20,6 +20,7 @@ test('prove JSON distinguishes proved and infrastructure-error outcomes', () => 
         proof: 'detects forbidden import',
         expected: 'red',
         ok: true,
+        reason: { kind: 'proved', target: 'architecture/no-infra' },
         result: {
           verdict: 'fail',
           scan: { source: 'test', startedAt: '2026-01-01T00:00:00.000Z', finishedAt: '2026-01-01T00:00:01.000Z', inspected: 1 },
@@ -56,4 +57,44 @@ test('prove JSON distinguishes proved and infrastructure-error outcomes', () => 
 
   const parsed = JSON.parse(formatJsonProofs(run));
   assert.equal(parsed.proofs[1].error.code, 'workspace-not-restored');
+  assert.equal(parsed.proofs[1].reason, undefined);
+});
+
+test('prove JSON says why a proof was judged and what the Check found', () => {
+  const scan = { source: 'test', startedAt: '', finishedAt: '', inspected: 1 };
+  const run: ProveProjectRun = {
+    project: baseProject,
+    exitCode: 1,
+    outcomes: [
+      {
+        status: 'completed',
+        gate: 'lint',
+        proof: 'a var in src is flagged',
+        expected: 'red',
+        ok: false,
+        reason: { kind: 'target-rule-not-breached', target: 'lint/no-var', breached: ['lint/no-let'] },
+        result: {
+          verdict: 'fail',
+          scan,
+          breaches: [{ rule: 'lint/no-let', code: 'no-let', message: 'src/a.mjs:3: use const', location: { file: 'src/a.mjs', line: 3, column: null } }],
+        },
+        workerPid: 1,
+      },
+      {
+        status: 'completed',
+        gate: 'policy',
+        proof: 'refuses without input',
+        expected: 'refuse',
+        ok: true,
+        reason: { kind: 'proved' },
+        result: { verdict: 'refuse', scan, why: { code: 'unavailable', message: 'No input', location: null } },
+        workerPid: 1,
+      },
+    ],
+  };
+
+  const report = buildJsonProveReport(run);
+  assert.deepEqual(report.proofs[0]?.reason, { kind: 'target-rule-not-breached', target: 'lint/no-var', breached: ['lint/no-let'] });
+  assert.deepEqual(report.proofs[0]?.check?.breaches?.map(item => [item.rule, item.message]), [['lint/no-let', 'src/a.mjs:3: use const']]);
+  assert.deepEqual(report.proofs[1]?.check, { verdict: 'refuse', refusal: { code: 'unavailable', message: 'No input', location: null } });
 });


### PR DESCRIPTION
## Problem

A prove run printed only `expected=red actual=fail`. The JSON report carried only `check.verdict`. A proved RED did not name the Rule that breached. A RED that failed because the wrong Rule breached looked the same as one that proved. The core computed the three-way evaluation and reduced it to `ok` before reporting.

An agent that used Redproof for a red-proof could not read "red for the right Rule" from the output. In an evaluation today it repeated three breaks by hand to learn the reason.

## Fix

A completed outcome keeps `reason: ProofEvaluation`. A proved RED carries its `target`. A RED blocked by a baseline that already breached the target has its own kind, `target-already-breached`. `ok` stays, so nothing that reads it changes.

The terminal reporter adds one indented line under each proof:

```text
✓ repository-policy / detects divergent package versions expected=red actual=fail
    breached repository/package-versions-and-internal-pins-align: Publishable packages do not share one version.
✓ repository-policy / refuses when a policy input cannot be read expected=refuse actual=refuse
    refused repository-policy-unavailable: Repository policy inputs could not be read.
✗ lint / a var is flagged expected=red actual=fail
    target lint/no-var not breached; breached lint/no-let
✗ lint / a var is flagged expected=red actual=pass
    expected fail, got pass; the mutation did not reach what the Rule guards
```

The first line of each proof is unchanged. A proved GREEN has no second line.

The JSON report adds `reason` and, under `check`, the `breaches` or the `refusal` in the shape the check report already uses. The schema declares `reason`. The report stays version 1. `ProofEvaluation` is exported.

## Verification

`npm run check` passes: 200 tests, 4 Gates with 22 Rules held, 31 proofs at their expected colour.

Red proofs. Dropping `reason` from the JSON builder fails "prove JSON says why a proof was judged and what the Check found". Dropping the second terminal line fails "a proof line says why it was judged as it was". Making a proved RED forget its target fails "RED proof proves when its mutation breaches the target, then restores the world". Restored, everything passes.