### PR TITLE
Model proof outcomes and report Rules as states, not flags

### DIFF
--- a/gates/repository-policy.ts
+++ b/gates/repository-policy.ts
@@ -57,7 +57,7 @@ export const proofs = defineProofs(gate, [
     rules.versionAlignment,
     'detects divergent package versions',
     mutate.replaceText(
-      locate.text({ files: 'packages/testing/package.json', find: '"version": "0.8.0"' }),
+      locate.text({ files: 'packages/testing/package.json', find: '"version": "0.9.0"' }),
       '"version": "0.6.1"',
     ),
   ),

--- a/package-lock.json
+++ b/package-lock.json
@@ -4952,10 +4952,10 @@
     },
     "packages/dependency-cruiser": {
       "name": "@redproof/dependency-cruiser",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "redproof": "0.8.0"
+        "redproof": "0.9.0"
       },
       "engines": {
         "node": ">=24"
@@ -4966,10 +4966,10 @@
     },
     "packages/eslint": {
       "name": "@redproof/eslint",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "redproof": "0.8.0"
+        "redproof": "0.9.0"
       },
       "engines": {
         "node": ">=24"
@@ -4979,7 +4979,7 @@
       }
     },
     "packages/redproof": {
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "bin": {
         "redproof": "dist/cli.js"
@@ -4990,10 +4990,10 @@
     },
     "packages/stryker": {
       "name": "@redproof/stryker",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "redproof": "0.8.0"
+        "redproof": "0.9.0"
       },
       "engines": {
         "node": ">=24"
@@ -5004,10 +5004,10 @@
     },
     "packages/testing": {
       "name": "@redproof/testing",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "redproof": "0.8.0"
+        "redproof": "0.9.0"
       },
       "engines": {
         "node": ">=24"

--- a/packages/dependency-cruiser/package.json
+++ b/packages/dependency-cruiser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redproof/dependency-cruiser",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Redproof adapter for dependency-cruiser architecture rules.",
   "type": "module",
   "exports": {
@@ -17,7 +17,7 @@
     "node": ">=24"
   },
   "dependencies": {
-    "redproof": "0.8.0"
+    "redproof": "0.9.0"
   },
   "peerDependencies": {
     "dependency-cruiser": ">=18"

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redproof/eslint",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Redproof adapter for ESLint rules.",
   "type": "module",
   "exports": {
@@ -17,7 +17,7 @@
     "node": ">=24"
   },
   "dependencies": {
-    "redproof": "0.8.0"
+    "redproof": "0.9.0"
   },
   "peerDependencies": {
     "eslint": ">=9"

--- a/packages/redproof/package.json
+++ b/packages/redproof/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redproof",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Prove your guardrails can fail. Redproof verifies that tests, linters, and architecture rules actually go red.",
   "keywords": [
     "testing",

--- a/packages/redproof/src/index.ts
+++ b/packages/redproof/src/index.ts
@@ -140,6 +140,8 @@ export {
   buildJsonCheckReport,
   buildJsonProveReport,
   buildSarif,
+  countBreachedRules,
+  countBreaches,
   formatCheck,
   formatCompactRun,
   formatGateDescription,
@@ -156,6 +158,7 @@ export {
   summarizeGateReports,
 } from './reporter/index.ts';
 export type {
+  BreachTotal,
   CheckReporterName,
   GateReportModel,
   JsonBreachV1,

--- a/packages/redproof/src/index.ts
+++ b/packages/redproof/src/index.ts
@@ -114,11 +114,14 @@ export { proofEstablished, runGate, runProof } from './proof/index.ts';
 export type {
   AbortedProofOutcome,
   CompletedProofOutcome,
+  GreenProofEvaluation,
   InfrastructureProofOutcome,
   ProofEvaluation,
   ProofInfrastructureError,
   ProofInfrastructureErrorCode,
   ProofOutcome,
+  RedProofEvaluation,
+  RefuseProofEvaluation,
   RestorationErrorCode,
   UnrestoredProofOutcome,
 } from './proof/index.ts';

--- a/packages/redproof/src/index.ts
+++ b/packages/redproof/src/index.ts
@@ -110,13 +110,17 @@ export type {
   LoadedProject,
 } from './project/index.ts';
 
-export { runGate, runProof } from './proof/index.ts';
+export { proofEstablished, runGate, runProof } from './proof/index.ts';
 export type {
+  AbortedProofOutcome,
   CompletedProofOutcome,
   InfrastructureProofOutcome,
   ProofEvaluation,
   ProofInfrastructureError,
+  ProofInfrastructureErrorCode,
   ProofOutcome,
+  RestorationErrorCode,
+  UnrestoredProofOutcome,
 } from './proof/index.ts';
 
 export {

--- a/packages/redproof/src/proof/core/evaluation.ts
+++ b/packages/redproof/src/proof/core/evaluation.ts
@@ -1,12 +1,16 @@
-import type { CheckResult, Proof, RuleRef } from '../../domain/index.ts';
+import type { CheckResult, Proof, RedProof, RuleRef } from '../../domain/index.ts';
 
-export type ProofEvaluation =
-  | { readonly kind: 'proved'; readonly target?: RuleRef }
-  | {
-      readonly kind: 'verdict-mismatch';
-      readonly expected: 'fail' | 'pass' | 'refuse';
-      readonly actual: CheckResult['verdict'];
-    }
+type Verdict = CheckResult['verdict'];
+
+type VerdictMismatch<Expected extends Verdict> = {
+  readonly kind: 'verdict-mismatch';
+  readonly expected: Expected;
+  readonly actual: Exclude<Verdict, Expected>;
+};
+
+export type RedProofEvaluation =
+  | { readonly kind: 'proved'; readonly target: RuleRef }
+  | VerdictMismatch<'fail'>
   | {
       readonly kind: 'target-rule-not-breached';
       readonly target: RuleRef;
@@ -18,43 +22,35 @@ export type ProofEvaluation =
       readonly breached: readonly RuleRef[];
     };
 
-function expectedVerdict(proof: Proof): CheckResult['verdict'] {
-  if (proof.expected === 'red') return 'fail';
-  if (proof.expected === 'green') return 'pass';
-  return 'refuse';
+export type GreenProofEvaluation = { readonly kind: 'proved' } | VerdictMismatch<'pass'>;
+
+export type RefuseProofEvaluation = { readonly kind: 'proved' } | VerdictMismatch<'refuse'>;
+
+export type ProofEvaluation = RedProofEvaluation | GreenProofEvaluation | RefuseProofEvaluation;
+
+export function evaluateRedProof(proof: RedProof, result: CheckResult): RedProofEvaluation {
+  if (result.verdict !== 'fail') return { kind: 'verdict-mismatch', expected: 'fail', actual: result.verdict };
+
+  const breached = result.breaches.map(item => item.rule);
+  if (!breached.includes(proof.target)) return { kind: 'target-rule-not-breached', target: proof.target, breached };
+  return { kind: 'proved', target: proof.target };
+}
+
+export function evaluateGreenProof(result: CheckResult): GreenProofEvaluation {
+  if (result.verdict !== 'pass') return { kind: 'verdict-mismatch', expected: 'pass', actual: result.verdict };
+  return { kind: 'proved' };
+}
+
+export function evaluateRefuseProof(result: CheckResult): RefuseProofEvaluation {
+  if (result.verdict !== 'refuse') return { kind: 'verdict-mismatch', expected: 'refuse', actual: result.verdict };
+  return { kind: 'proved' };
 }
 
 /** Pure proof semantics: given a Proof claim and a CheckResult, decide whether it was established. */
 export function evaluateProof(proof: Proof, result: CheckResult): ProofEvaluation {
-  const expected = expectedVerdict(proof);
-
-  if (result.verdict !== expected) {
-    return {
-      kind: 'verdict-mismatch',
-      expected,
-      actual: result.verdict,
-    };
-  }
-
-  if (proof.expected === 'red') {
-    // The verdict narrowing above establishes result.verdict === 'fail' at runtime,
-    // but TypeScript cannot correlate it through expectedVerdict().
-    if (result.verdict !== 'fail') {
-      return { kind: 'verdict-mismatch', expected: 'fail', actual: result.verdict };
-    }
-
-    const breached = result.breaches.map(item => item.rule);
-    if (!breached.includes(proof.target)) {
-      return {
-        kind: 'target-rule-not-breached',
-        target: proof.target,
-        breached,
-      };
-    }
-    return { kind: 'proved', target: proof.target };
-  }
-
-  return { kind: 'proved' };
+  if (proof.expected === 'red') return evaluateRedProof(proof, result);
+  if (proof.expected === 'green') return evaluateGreenProof(result);
+  return evaluateRefuseProof(result);
 }
 
 export function proofSucceeded(evaluation: ProofEvaluation): boolean {

--- a/packages/redproof/src/proof/core/index.ts
+++ b/packages/redproof/src/proof/core/index.ts
@@ -1,4 +1,9 @@
-export type { ProofEvaluation } from './evaluation.ts';
+export type {
+  GreenProofEvaluation,
+  ProofEvaluation,
+  RedProofEvaluation,
+  RefuseProofEvaluation,
+} from './evaluation.ts';
 export { proofEstablished } from './outcome.ts';
 export type {
   AbortedProofOutcome,

--- a/packages/redproof/src/proof/core/index.ts
+++ b/packages/redproof/src/proof/core/index.ts
@@ -1,8 +1,13 @@
 export type { ProofEvaluation } from './evaluation.ts';
+export { proofEstablished } from './outcome.ts';
 export type {
+  AbortedProofOutcome,
   CompletedProofOutcome,
   InfrastructureProofOutcome,
   ProofInfrastructureError,
+  ProofInfrastructureErrorCode,
   ProofOutcome,
+  RestorationErrorCode,
+  UnrestoredProofOutcome,
 } from './outcome.ts';
 export { canReuseWorkspace, verifyProofRestoration } from './restoration.ts';

--- a/packages/redproof/src/proof/core/lifecycle.ts
+++ b/packages/redproof/src/proof/core/lifecycle.ts
@@ -1,5 +1,5 @@
-import type { CheckResult, Gate, Proof } from '../../domain/index.ts';
-import { evaluateProof, proofSucceeded } from './evaluation.ts';
+import type { CheckResult, Gate, Proof, RedProof } from '../../domain/index.ts';
+import { evaluateProof } from './evaluation.ts';
 import type {
   CompletedProofOutcome,
   InfrastructureProofOutcome,
@@ -13,13 +13,13 @@ export type ProofFailure =
   | { readonly step: 'restore-after-check-threw'; readonly error: unknown }
   | { readonly step: 'restore'; readonly error: unknown; readonly result: CheckResult };
 
-const FAILURE_CODES: Record<ProofFailure['step'], ProofInfrastructureError['code']> = {
+const FAILURE_CODES = {
   baseline: 'check-threw',
   apply: 'mutation-apply-failed',
   check: 'check-threw',
   'restore-after-check-threw': 'mutation-restore-failed',
   restore: 'mutation-restore-failed',
-};
+} as const satisfies Record<ProofFailure['step'], ProofInfrastructureError['code']>;
 
 const FAILURE_MESSAGES: Record<ProofFailure['step'], string> = {
   baseline: 'The baseline Check threw instead of returning a CheckResult.',
@@ -34,15 +34,13 @@ function errorDetail(error: unknown): string {
 }
 
 /** A RED proof needs a mutation to cause the breach. A target already breached before mutation proves nothing. */
-export function baselineBlocksProof(proof: Proof, baseline: CheckResult): boolean {
-  return proof.expected === 'red'
-    && baseline.verdict === 'fail'
-    && baseline.breaches.some(item => item.rule === proof.target);
+export function baselineBlocksProof(proof: RedProof, baseline: CheckResult): boolean {
+  return baseline.verdict === 'fail' && baseline.breaches.some(item => item.rule === proof.target);
 }
 
 export function baselineOutcome(
   gate: Gate<any>,
-  proof: Proof,
+  proof: RedProof,
   baseline: CheckResult,
   workerPid: number,
 ): CompletedProofOutcome {
@@ -52,8 +50,7 @@ export function baselineOutcome(
     gate: gate.id,
     proof: proof.name,
     expected: proof.expected,
-    ok: false,
-    reason: { kind: 'target-already-breached', target: proof.expected === 'red' ? proof.target : '', breached },
+    reason: { kind: 'target-already-breached', target: proof.target, breached },
     result: baseline,
     workerPid,
   };
@@ -65,14 +62,12 @@ export function completedOutcome(
   result: CheckResult,
   workerPid: number,
 ): CompletedProofOutcome {
-  const reason = evaluateProof(proof, result);
   return {
     status: 'completed',
     gate: gate.id,
     proof: proof.name,
     expected: proof.expected,
-    ok: proofSucceeded(reason),
-    reason,
+    reason: evaluateProof(proof, result),
     result,
     workerPid,
   };
@@ -84,18 +79,32 @@ export function failedOutcome(
   failure: ProofFailure,
   workerPid: number,
 ): InfrastructureProofOutcome {
+  if (failure.step === 'restore') {
+    return {
+      status: 'unrestored',
+      gate: gate.id,
+      proof: proof.name,
+      expected: proof.expected,
+      error: {
+        code: FAILURE_CODES.restore,
+        message: FAILURE_MESSAGES.restore,
+        detail: errorDetail(failure.error),
+      },
+      result: failure.result,
+      workerPid,
+    };
+  }
+
   return {
-    status: 'error',
+    status: 'aborted',
     gate: gate.id,
     proof: proof.name,
     expected: proof.expected,
-    ok: false,
     error: {
       code: FAILURE_CODES[failure.step],
       message: FAILURE_MESSAGES[failure.step],
       detail: errorDetail(failure.error),
     },
-    ...(failure.step === 'restore' ? { result: failure.result } : {}),
     workerPid,
   };
 }

--- a/packages/redproof/src/proof/core/lifecycle.ts
+++ b/packages/redproof/src/proof/core/lifecycle.ts
@@ -1,5 +1,5 @@
 import type { CheckResult, Gate, Proof, RedProof } from '../../domain/index.ts';
-import { evaluateProof } from './evaluation.ts';
+import { evaluateGreenProof, evaluateRedProof, evaluateRefuseProof } from './evaluation.ts';
 import type {
   CompletedProofOutcome,
   InfrastructureProofOutcome,
@@ -62,15 +62,10 @@ export function completedOutcome(
   result: CheckResult,
   workerPid: number,
 ): CompletedProofOutcome {
-  return {
-    status: 'completed',
-    gate: gate.id,
-    proof: proof.name,
-    expected: proof.expected,
-    reason: evaluateProof(proof, result),
-    result,
-    workerPid,
-  };
+  const completed = { status: 'completed', gate: gate.id, proof: proof.name, result, workerPid } as const;
+  if (proof.expected === 'red') return { ...completed, expected: 'red', reason: evaluateRedProof(proof, result) };
+  if (proof.expected === 'green') return { ...completed, expected: 'green', reason: evaluateGreenProof(result) };
+  return { ...completed, expected: 'refuse', reason: evaluateRefuseProof(result) };
 }
 
 export function failedOutcome(

--- a/packages/redproof/src/proof/core/outcome.ts
+++ b/packages/redproof/src/proof/core/outcome.ts
@@ -1,5 +1,10 @@
 import type { CheckResult, Proof } from '../../domain/index.ts';
-import { proofSucceeded, type ProofEvaluation } from './evaluation.ts';
+import {
+  proofSucceeded,
+  type GreenProofEvaluation,
+  type RedProofEvaluation,
+  type RefuseProofEvaluation,
+} from './evaluation.ts';
 
 export type RestorationErrorCode = 'mutation-restore-failed' | 'workspace-not-restored';
 
@@ -16,16 +21,21 @@ export type ProofInfrastructureError<
   readonly detail?: string;
 };
 
-export type CompletedProofOutcome = {
+type Completed<Expected extends Proof['expected'], Reason> = {
   readonly status: 'completed';
   readonly gate: string;
   readonly proof: string;
-  readonly expected: Proof['expected'];
+  readonly expected: Expected;
   /** How the proof was judged. */
-  readonly reason: ProofEvaluation;
+  readonly reason: Reason;
   readonly result: CheckResult;
   readonly workerPid: number;
 };
+
+export type CompletedProofOutcome =
+  | Completed<'red', RedProofEvaluation>
+  | Completed<'green', GreenProofEvaluation>
+  | Completed<'refuse', RefuseProofEvaluation>;
 
 /** Infrastructure failed before the Check returned a result. */
 export type AbortedProofOutcome = {

--- a/packages/redproof/src/proof/core/outcome.ts
+++ b/packages/redproof/src/proof/core/outcome.ts
@@ -1,12 +1,17 @@
 import type { CheckResult, Proof } from '../../domain/index.ts';
-import type { ProofEvaluation } from './evaluation.ts';
+import { proofSucceeded, type ProofEvaluation } from './evaluation.ts';
 
-export type ProofInfrastructureError = {
-  readonly code:
-    | 'mutation-apply-failed'
-    | 'check-threw'
-    | 'mutation-restore-failed'
-    | 'workspace-not-restored';
+export type RestorationErrorCode = 'mutation-restore-failed' | 'workspace-not-restored';
+
+export type ProofInfrastructureErrorCode =
+  | 'mutation-apply-failed'
+  | 'check-threw'
+  | RestorationErrorCode;
+
+export type ProofInfrastructureError<
+  Code extends ProofInfrastructureErrorCode = ProofInfrastructureErrorCode,
+> = {
+  readonly code: Code;
   readonly message: string;
   readonly detail?: string;
 };
@@ -16,22 +21,37 @@ export type CompletedProofOutcome = {
   readonly gate: string;
   readonly proof: string;
   readonly expected: Proof['expected'];
-  readonly ok: boolean;
-  /** How the proof was judged. `ok` is `reason.kind === 'proved'`. */
+  /** How the proof was judged. */
   readonly reason: ProofEvaluation;
   readonly result: CheckResult;
   readonly workerPid: number;
 };
 
-export type InfrastructureProofOutcome = {
-  readonly status: 'error';
+/** Infrastructure failed before the Check returned a result. */
+export type AbortedProofOutcome = {
+  readonly status: 'aborted';
   readonly gate: string;
   readonly proof: string;
   readonly expected: Proof['expected'];
-  readonly ok: false;
   readonly error: ProofInfrastructureError;
-  readonly result?: CheckResult;
   readonly workerPid: number;
 };
 
+/** The Check returned a result, then the workspace did not return to its baseline. */
+export type UnrestoredProofOutcome = {
+  readonly status: 'unrestored';
+  readonly gate: string;
+  readonly proof: string;
+  readonly expected: Proof['expected'];
+  readonly error: ProofInfrastructureError<RestorationErrorCode>;
+  readonly result: CheckResult;
+  readonly workerPid: number;
+};
+
+export type InfrastructureProofOutcome = AbortedProofOutcome | UnrestoredProofOutcome;
+
 export type ProofOutcome = CompletedProofOutcome | InfrastructureProofOutcome;
+
+export function proofEstablished(outcome: ProofOutcome): boolean {
+  return outcome.status === 'completed' && proofSucceeded(outcome.reason);
+}

--- a/packages/redproof/src/proof/core/restoration.ts
+++ b/packages/redproof/src/proof/core/restoration.ts
@@ -1,4 +1,4 @@
-import type { InfrastructureProofOutcome, ProofOutcome } from './outcome.ts';
+import type { ProofInfrastructureError, ProofOutcome, RestorationErrorCode } from './outcome.ts';
 import type { Freshness } from '../../workspace/core/index.ts';
 
 /** Pure interpretation of workspace verification after a proof has run and its UndoMutation completed. */
@@ -9,26 +9,20 @@ export function verifyProofRestoration(
 ): ProofOutcome {
   if (freshness.kind === 'fresh') return outcome;
 
-  const error: InfrastructureProofOutcome = {
-    status: 'error',
-    gate: outcome.gate,
-    proof: outcome.proof,
-    expected: outcome.expected,
-    ok: false,
-    error: {
-      code: 'workspace-not-restored',
-      message: 'The Gate workspace did not return to its baseline after the proof.',
-      detail: freshness.why,
-    },
-    ...(outcome.status === 'completed' ? { result: outcome.result } : outcome.result ? { result: outcome.result } : {}),
-    workerPid,
+  const error: ProofInfrastructureError<RestorationErrorCode> = {
+    code: 'workspace-not-restored',
+    message: 'The Gate workspace did not return to its baseline after the proof.',
+    detail: freshness.why,
   };
+  const identity = { gate: outcome.gate, proof: outcome.proof, expected: outcome.expected, workerPid };
 
-  return error;
+  if (outcome.status === 'aborted') return { status: 'aborted', ...identity, error };
+  return { status: 'unrestored', ...identity, error, result: outcome.result };
 }
 
 /** A Gate copy may only be reused when proof infrastructure left it trustworthy. */
 export function canReuseWorkspace(outcome: ProofOutcome): boolean {
-  return outcome.status !== 'error'
-    || (outcome.error.code !== 'mutation-restore-failed' && outcome.error.code !== 'workspace-not-restored');
+  if (outcome.status === 'completed') return true;
+  if (outcome.status === 'unrestored') return false;
+  return outcome.error.code !== 'mutation-restore-failed' && outcome.error.code !== 'workspace-not-restored';
 }

--- a/packages/redproof/src/reporter/core/check-report.ts
+++ b/packages/redproof/src/reporter/core/check-report.ts
@@ -1,7 +1,7 @@
 import { relative } from 'node:path';
 import type { Breach, CountingCapability, Scan, Diagnostic } from '../../domain/index.ts';
 import type { CheckProjectRun, GateRun } from '../../run/core/index.ts';
-import { buildGateReportModel, summarizeGateReports } from './model.ts';
+import { buildGateReportModel, summarizeGateReports, type RuleReportState } from './model.ts';
 
 export type ReportVersion = 1;
 
@@ -86,6 +86,12 @@ function breachToJson(breach: Breach): JsonBreachV1 {
   };
 }
 
+function ruleBreachCount(state: RuleReportState, counting: CountingCapability): number | null {
+  if (state.kind === 'held') return 0;
+  if (state.kind !== 'breached') return null;
+  return counting.kind === 'supported' ? state.breaches.length : null;
+}
+
 function gateToJson(run: GateRun, root: string): JsonGateV1 {
   const gate = run.module.gate;
   const model = buildGateReportModel(gate.adapter, run.result);
@@ -103,8 +109,8 @@ function gateToJson(run: GateRun, root: string): JsonGateV1 {
       id: item.rule.id,
       description: item.rule.description,
       status: item.state.kind,
-      breachCount: item.state.kind === 'breached' ? item.state.count : item.state.kind === 'held' ? 0 : null,
-      breaches: item.breaches.map(breachToJson),
+      breachCount: ruleBreachCount(item.state, model.counting),
+      breaches: item.state.kind === 'breached' ? item.state.breaches.map(breachToJson) : [],
     })),
     ...(run.result.verdict === 'refuse' ? { refusal: diagnosticToJson(run.result.why) } : {}),
   };
@@ -140,9 +146,7 @@ export function buildJsonCheckReport(run: CheckProjectRun): JsonCheckReportV1 {
         unknown: summary.unknownRules,
         total: summary.totalRules,
       },
-      breaches: summary.exactBreachCount
-        ? { kind: 'exact', count: summary.breaches }
-        : { kind: 'not-countable' },
+      breaches: summary.breaches,
     },
   };
 }

--- a/packages/redproof/src/reporter/core/compact.ts
+++ b/packages/redproof/src/reporter/core/compact.ts
@@ -25,7 +25,7 @@ export function formatCompactRun(run: CheckProjectRun): string {
       const model = buildGateReportModel(item.module.gate.adapter, item.result);
       for (const rule of model.rules) {
         if (rule.state.kind !== 'breached') continue;
-        for (const breach of rule.breaches) {
+        for (const breach of rule.state.breaches) {
           lines.push(diagnosticLine(breach.rule, breach));
         }
       }

--- a/packages/redproof/src/reporter/core/json.ts
+++ b/packages/redproof/src/reporter/core/json.ts
@@ -1,5 +1,5 @@
 import type { CheckResult } from '../../domain/index.ts';
-import type { ProofEvaluation } from '../../proof/core/index.ts';
+import { proofEstablished, type ProofEvaluation } from '../../proof/core/index.ts';
 import type { CheckProjectRun, ProveProjectRun } from '../../run/core/index.ts';
 import { buildJsonCheckReport, type JsonBreachV1, type JsonDiagnosticV1 } from './check-report.ts';
 
@@ -79,13 +79,13 @@ export function buildJsonProveReport(run: ProveProjectRun): JsonProveReportV1 {
       gate: outcome.gate,
       proof: outcome.proof,
       expected: outcome.expected,
-      status: outcome.status === 'error'
+      status: outcome.status !== 'completed'
         ? 'infrastructure-error'
-        : outcome.ok ? 'proved' : 'not-proved',
+        : proofEstablished(outcome) ? 'proved' : 'not-proved',
       workerPid: outcome.workerPid,
       ...(outcome.status === 'completed' ? { reason: outcome.reason } : {}),
-      ...(outcome.result ? { check: jsonCheck(outcome.result) } : {}),
-      ...(outcome.status === 'error'
+      ...(outcome.status !== 'aborted' ? { check: jsonCheck(outcome.result) } : {}),
+      ...(outcome.status !== 'completed'
         ? {
             error: {
               code: outcome.error.code,

--- a/packages/redproof/src/reporter/core/model.ts
+++ b/packages/redproof/src/reporter/core/model.ts
@@ -3,6 +3,7 @@ import type {
   Breach,
   CheckResult,
   CountingCapability,
+  NonEmptyList,
   Rule,
   RuleRef,
 } from '../../domain/index.ts';
@@ -11,21 +12,22 @@ export type RuleReportState =
   | { readonly kind: 'held' }
   | { readonly kind: 'undecided' }
   | { readonly kind: 'unknown' }
-  | { readonly kind: 'breached'; readonly count: number | null };
+  | { readonly kind: 'breached'; readonly breaches: NonEmptyList<Breach> };
 
 export type RuleReport = {
   readonly rule: Rule;
   readonly state: RuleReportState;
-  readonly breaches: readonly Breach[];
 };
 
 export type GateReportModel = {
   readonly verdict: CheckResult['verdict'];
   readonly counting: CountingCapability;
   readonly rules: readonly RuleReport[];
-  readonly breachedRules: number;
-  readonly breachCount: number;
 };
+
+export type BreachTotal =
+  | { readonly kind: 'exact'; readonly count: number }
+  | { readonly kind: 'not-countable' };
 
 export type RunSummary = {
   readonly passedGates: number;
@@ -36,8 +38,7 @@ export type RunSummary = {
   readonly undecidedRules: number;
   readonly unknownRules: number;
   readonly totalRules: number;
-  readonly breaches: number;
-  readonly exactBreachCount: boolean;
+  readonly breaches: BreachTotal;
 };
 
 function rulesOf(adapter: Adapter<any>): readonly Rule[] {
@@ -63,9 +64,7 @@ export function buildGateReportModel(adapter: Adapter<any>, result: CheckResult)
     return {
       verdict: 'pass',
       counting,
-      rules: rules.map(rule => ({ rule, state: { kind: 'held' }, breaches: [] })),
-      breachedRules: 0,
-      breachCount: 0,
+      rules: rules.map(rule => ({ rule, state: { kind: 'held' } })),
     };
   }
 
@@ -73,37 +72,34 @@ export function buildGateReportModel(adapter: Adapter<any>, result: CheckResult)
     return {
       verdict: 'refuse',
       counting,
-      rules: rules.map(rule => ({ rule, state: { kind: 'undecided' }, breaches: [] })),
-      breachedRules: 0,
-      breachCount: 0,
+      rules: rules.map(rule => ({ rule, state: { kind: 'undecided' } })),
     };
   }
 
   const groups = groupBreaches(result);
-  const ruleReports = rules.map(rule => {
-    const breaches = groups.get(rule.id) ?? [];
-    if (breaches.length > 0) {
-      return {
-        rule,
-        state: { kind: 'breached', count: counting.kind === 'supported' ? breaches.length : null } as const,
-        breaches,
-      };
-    }
-
-    return {
-      rule,
-      state: counting.kind === 'supported' ? { kind: 'held' as const } : { kind: 'unknown' as const },
-      breaches,
-    };
-  });
-
   return {
     verdict: 'fail',
     counting,
-    rules: ruleReports,
-    breachedRules: new Set(result.breaches.map(breach => breach.rule)).size,
-    breachCount: result.breaches.length,
+    rules: rules.map(rule => {
+      const breaches = groups.get(rule.id) ?? [];
+      if (breaches.length > 0) {
+        return { rule, state: { kind: 'breached', breaches: [breaches[0]!, ...breaches.slice(1)] } };
+      }
+      return { rule, state: { kind: counting.kind === 'supported' ? 'held' : 'unknown' } };
+    }),
   };
+}
+
+export function countBreachedRules(model: GateReportModel): number {
+  return model.rules.filter(item => item.state.kind === 'breached').length;
+}
+
+export function countBreaches(model: GateReportModel): number {
+  let total = 0;
+  for (const item of model.rules) {
+    if (item.state.kind === 'breached') total += item.state.breaches.length;
+  }
+  return total;
 }
 
 /** Pure aggregation used by terminal and future reporters. */
@@ -117,7 +113,7 @@ export function summarizeGateReports(gates: readonly GateReportModel[]): RunSumm
   let unknownRules = 0;
   let totalRules = 0;
   let breaches = 0;
-  let exactBreachCount = true;
+  let countable = true;
 
   for (const gate of gates) {
     if (gate.verdict === 'pass') passedGates++;
@@ -125,8 +121,8 @@ export function summarizeGateReports(gates: readonly GateReportModel[]): RunSumm
     else refusedGates++;
 
     totalRules += gate.rules.length;
-    breaches += gate.breachCount;
-    if (gate.verdict === 'fail' && gate.counting.kind === 'unsupported') exactBreachCount = false;
+    breaches += countBreaches(gate);
+    if (gate.verdict === 'fail' && gate.counting.kind === 'unsupported') countable = false;
 
     for (const rule of gate.rules) {
       if (rule.state.kind === 'held') heldRules++;
@@ -145,7 +141,6 @@ export function summarizeGateReports(gates: readonly GateReportModel[]): RunSumm
     undecidedRules,
     unknownRules,
     totalRules,
-    breaches,
-    exactBreachCount,
+    breaches: countable ? { kind: 'exact', count: breaches } : { kind: 'not-countable' },
   };
 }

--- a/packages/redproof/src/reporter/core/terminal.ts
+++ b/packages/redproof/src/reporter/core/terminal.ts
@@ -1,7 +1,7 @@
 import { relative } from 'node:path';
 import type { CheckResult, Diagnostic, Rule } from '../../domain/index.ts';
 import type { GateDescription } from '../../project/core/index.ts';
-import type { CompletedProofOutcome, ProofOutcome } from '../../proof/core/index.ts';
+import { proofEstablished, type CompletedProofOutcome, type ProofOutcome } from '../../proof/core/index.ts';
 import type { CheckProjectRun, GateRun } from '../../run/core/index.ts';
 import { buildGateReportModel, summarizeGateReports, type RunSummary } from './model.ts';
 
@@ -282,9 +282,9 @@ export function proofReason(outcome: CompletedProofOutcome): string {
 }
 
 export function formatProof(outcome: ProofOutcome): string {
-  const mark = outcome.ok ? '✓' : '✗';
-  if (outcome.status === 'error') {
-    const actual = outcome.result ? ` actual=${outcome.result.verdict}` : '';
+  const mark = proofEstablished(outcome) ? '✓' : '✗';
+  if (outcome.status !== 'completed') {
+    const actual = outcome.status === 'unrestored' ? ` actual=${outcome.result.verdict}` : '';
     return `${mark} ${outcome.gate} / ${outcome.proof} expected=${outcome.expected}${actual} error=${outcome.error.code}\n  ${outcome.error.message}${outcome.error.detail ? `\n  ${outcome.error.detail}` : ''}`;
   }
   const line = `${mark} ${outcome.gate} / ${outcome.proof} expected=${outcome.expected} actual=${outcome.result.verdict}`;

--- a/packages/redproof/src/reporter/core/terminal.ts
+++ b/packages/redproof/src/reporter/core/terminal.ts
@@ -262,26 +262,32 @@ function checkOutcomeDetail(result: CheckResult, rule?: string): string {
 }
 
 /** One line that says why a completed proof was judged as it was. Empty when there is nothing to add. */
-export function proofReason(outcome: CompletedProofOutcome): string {
-  const reason = outcome.reason;
-  const result = outcome.result;
-
-  if (reason.kind === 'proved') {
-    if (outcome.expected === 'red') return `breached ${checkOutcomeDetail(result, reason.target)}`;
-    if (outcome.expected === 'refuse') return `refused ${checkOutcomeDetail(result)}`;
-    return '';
-  }
-  if (reason.kind === 'target-rule-not-breached') {
-    return `target ${reason.target} not breached; breached ${reason.breached.join(', ')}`;
-  }
-  if (reason.kind === 'target-already-breached') {
-    return `target ${reason.target} was already breached before the mutation; breached ${reason.breached.join(', ')}`;
-  }
-  const detail = checkOutcomeDetail(result);
-  if (result.verdict === 'pass' && reason.expected === 'fail') {
+function mismatchReason(reason: { readonly expected: string; readonly actual: string }, result: CheckResult): string {
+  if (reason.expected === 'fail' && reason.actual === 'pass') {
     return `expected ${reason.expected}, got ${reason.actual}; the mutation did not reach what the Rule guards`;
   }
+  const detail = checkOutcomeDetail(result);
   return `expected ${reason.expected}, got ${reason.actual}${detail ? `: ${detail}` : ''}`;
+}
+
+export function proofReason(outcome: CompletedProofOutcome): string {
+  const result = outcome.result;
+
+  if (outcome.expected === 'red') {
+    const reason = outcome.reason;
+    if (reason.kind === 'proved') return `breached ${checkOutcomeDetail(result, reason.target)}`;
+    if (reason.kind === 'target-rule-not-breached') {
+      return `target ${reason.target} not breached; breached ${reason.breached.join(', ')}`;
+    }
+    if (reason.kind === 'target-already-breached') {
+      return `target ${reason.target} was already breached before the mutation; breached ${reason.breached.join(', ')}`;
+    }
+    return mismatchReason(reason, result);
+  }
+
+  const reason = outcome.reason;
+  if (reason.kind === 'verdict-mismatch') return mismatchReason(reason, result);
+  return outcome.expected === 'refuse' ? `refused ${checkOutcomeDetail(result)}` : '';
 }
 
 export function formatProof(outcome: ProofOutcome): string {

--- a/packages/redproof/src/reporter/core/terminal.ts
+++ b/packages/redproof/src/reporter/core/terminal.ts
@@ -3,7 +3,7 @@ import type { CheckResult, Diagnostic, Rule } from '../../domain/index.ts';
 import type { GateDescription } from '../../project/core/index.ts';
 import { proofEstablished, type CompletedProofOutcome, type ProofOutcome } from '../../proof/core/index.ts';
 import type { CheckProjectRun, GateRun } from '../../run/core/index.ts';
-import { buildGateReportModel, summarizeGateReports, type RunSummary } from './model.ts';
+import { buildGateReportModel, countBreachedRules, countBreaches, summarizeGateReports, type RunSummary } from './model.ts';
 
 /** Source lines by the file named in a Diagnostic location. A file that is absent shows no excerpt. */
 export type SourceExcerpts = ReadonlyMap<string, readonly string[]>;
@@ -66,7 +66,8 @@ function gateStatusSuffix(run: GateRun): string {
   if (model.verdict === 'refuse') return `(${label} | refused)`;
   if (model.counting.kind === 'unsupported') return `(${label} | breach detected)`;
 
-  return `(${label} | ${model.breachedRules} breached | ${model.breachCount} ${model.breachCount === 1 ? 'breach' : 'breaches'})`;
+  const total = countBreaches(model);
+  return `(${label} | ${countBreachedRules(model)} breached | ${total} ${total === 1 ? 'breach' : 'breaches'})`;
 }
 
 function renderGateLine(run: GateRun, root: string, color: boolean): string {
@@ -91,9 +92,10 @@ function renderRuleTree(run: GateRun, color: boolean): string[] {
     if (item.state.kind === 'unknown') return `   ${yellow(color, glyph.unknown)} ${name} ${dim(color, '(not established)')}`;
     if (item.state.kind === 'undecided') return '';
 
-    const suffix = item.state.count == null
+    const count = item.state.breaches.length;
+    const suffix = model.counting.kind === 'unsupported'
       ? 'breach detected'
-      : `${item.state.count} ${item.state.count === 1 ? 'breach' : 'breaches'}`;
+      : `${count} ${count === 1 ? 'breach' : 'breaches'}`;
     return `   ${red(color, glyph.fail)} ${name}\n     ${red(color, glyph.breach)} ${suffix}`;
   }).filter(Boolean);
 }
@@ -156,11 +158,12 @@ function renderFailureDetails(run: GateRun, projectRoot: string, sources: Source
     if (item.state.kind !== 'breached') continue;
     const name = ruleName(item.rule);
     sections.push('', '', ` ${red(options.color, 'FAIL')}  ${file} > ${name}`, '');
-    if (item.state.count != null && item.state.count > 1) sections.push(`${item.state.count} breaches`, '');
+    const breaches = item.state.breaches;
+    if (model.counting.kind === 'supported' && breaches.length > 1) sections.push(`${breaches.length} breaches`, '');
 
-    for (let index = 0; index < item.breaches.length; index++) {
+    for (let index = 0; index < breaches.length; index++) {
       if (index > 0) sections.push('');
-      sections.push(...renderDiagnostic(sources, item.breaches[index]!, options));
+      sections.push(...renderDiagnostic(sources, breaches[index]!, options));
     }
   }
 
@@ -193,7 +196,7 @@ function ruleParts(summary: RunSummary, color: boolean): string[] {
   const parts: string[] = [];
   if (summary.heldRules) parts.push(green(color, `${summary.heldRules} held`));
   if (summary.breachedRules) {
-    const count = summary.exactBreachCount ? String(summary.breachedRules) : `${summary.breachedRules}+`;
+    const count = summary.breaches.kind === 'exact' ? String(summary.breachedRules) : `${summary.breachedRules}+`;
     parts.push(red(color, `${count} breached`));
   }
   if (summary.undecidedRules) parts.push(yellow(color, `${summary.undecidedRules} undecided`));
@@ -211,7 +214,7 @@ function summaryRows(run: CheckProjectRun, options: Required<ReportOptions>): st
   ];
 
   if (summary.failedGates) {
-    rows.push(` Breaches   ${summary.exactBreachCount ? String(summary.breaches) : 'not countable'}`);
+    rows.push(` Breaches   ${summary.breaches.kind === 'exact' ? String(summary.breaches.count) : 'not countable'}`);
   }
   rows.push(` Start at   ${time(run.startedAt)}`);
   rows.push(` Duration   ${ms(run.durationMs)}`);

--- a/packages/redproof/src/run/core/exit-code.ts
+++ b/packages/redproof/src/run/core/exit-code.ts
@@ -1,4 +1,5 @@
 import type { CheckResult } from '../../domain/index.ts';
+import { proofEstablished, type ProofOutcome } from '../../proof/core/index.ts';
 
 /** Pure process-status policy for a project Check run. REFUSE takes precedence over FAIL. */
 export function checkExitCode(results: readonly CheckResult[], refusalExit: number): number {
@@ -8,6 +9,6 @@ export function checkExitCode(results: readonly CheckResult[], refusalExit: numb
 }
 
 /** Pure process-status policy for proof runs. */
-export function proofExitCode(outcomes: readonly { readonly ok: boolean }[]): number {
-  return outcomes.every(outcome => outcome.ok) ? 0 : 1;
+export function proofExitCode(outcomes: readonly ProofOutcome[]): number {
+  return outcomes.every(proofEstablished) ? 0 : 1;
 }

--- a/packages/stryker/package.json
+++ b/packages/stryker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redproof/stryker",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Redproof adapter for Stryker mutation testing.",
   "type": "module",
   "exports": {
@@ -17,7 +17,7 @@
     "node": ">=24"
   },
   "dependencies": {
-    "redproof": "0.8.0"
+    "redproof": "0.9.0"
   },
   "peerDependencies": {
     "@stryker-mutator/core": ">=10"

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redproof/testing",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Redproof adapter for test suites and JUnit XML reports.",
   "type": "module",
   "exports": {
@@ -17,7 +17,7 @@
     "node": ">=24"
   },
   "dependencies": {
-    "redproof": "0.8.0"
+    "redproof": "0.9.0"
   },
   "repository": {
     "type": "git",

--- a/tests/adapters/integration.test.ts
+++ b/tests/adapters/integration.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { resolve } from 'node:path';
 import test from 'node:test';
-import { checkProject, proveProject } from 'redproof';
+import { checkProject, proofEstablished, proveProject } from 'redproof';
 
 const configOf = (name: string) => resolve(`fixtures/${name}/redproof.config.ts`);
 
@@ -15,7 +15,7 @@ test('dependency-cruiser adapter passes clean architecture and proves both mappe
   assert.deepEqual(
     proof.outcomes.map(outcome => [
       outcome.expected,
-      outcome.ok,
+      proofEstablished(outcome),
       outcome.status === 'completed' ? outcome.result.verdict : outcome.error.code,
     ]),
     [
@@ -37,7 +37,7 @@ test('Stryker adapter passes strong tests and proves mutant detection, score, an
   assert.deepEqual(
     proof.outcomes.map(outcome => [
       outcome.expected,
-      outcome.ok,
+      proofEstablished(outcome),
       outcome.status === 'completed' ? outcome.result.verdict : outcome.error.code,
     ]),
     [

--- a/tests/fixture.test.ts
+++ b/tests/fixture.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { readFile, rename, stat } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import test from 'node:test';
-import { checkProject, loadProject, proveProject } from 'redproof';
+import { checkProject, loadProject, proofEstablished, proveProject } from 'redproof';
 
 const config = resolve('fixtures/eslint-project/redproof.config.ts');
 const source = resolve('fixtures/eslint-project/src/clean.js');
@@ -34,7 +34,7 @@ test('fixture proves ESLint red, green, and refuse and restores mutations', asyn
   assert.deepEqual(
     run.outcomes.map(outcome => [
       outcome.expected,
-      outcome.ok,
+      proofEstablished(outcome),
       outcome.status === 'completed' ? outcome.result.verdict : outcome.error.code,
     ]),
     [

--- a/tests/proof.core.test.ts
+++ b/tests/proof.core.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { breach, fail, pass, proof, refuse, type Scan } from 'redproof';
+import { breach, fail, pass, proof, proofEstablished, refuse, type Scan } from 'redproof';
 import { evaluateProof } from '../packages/redproof/src/proof/core/evaluation.ts';
 import type { ProofOutcome } from '../packages/redproof/src/proof/core/outcome.ts';
 import { canReuseWorkspace, verifyProofRestoration } from '../packages/redproof/src/proof/core/restoration.ts';
@@ -46,7 +46,6 @@ test('restoration failure replaces proof success and prevents copy reuse', () =>
     gate: 'g',
     proof: 'p',
     expected: 'green',
-    ok: true,
     reason: { kind: 'proved' },
     result,
     workerPid: 10,
@@ -58,11 +57,30 @@ test('restoration failure replaces proof success and prevents copy reuse', () =>
     10,
   );
 
-  assert.equal(outcome.status, 'error');
-  assert.equal(outcome.ok, false);
-  if (outcome.status !== 'error') throw new Error('expected error');
+  assert.equal(outcome.status, 'unrestored');
+  assert.equal(proofEstablished(outcome), false);
+  if (outcome.status !== 'unrestored') throw new Error('expected an unrestored proof');
   assert.equal(outcome.error.code, 'workspace-not-restored');
   assert.equal(outcome.result, result);
   assert.equal(canReuseWorkspace(outcome), false);
   assert.equal(canReuseWorkspace(completed), true);
+});
+
+test('a stale workspace after an aborted proof stays aborted, because no Check result exists', () => {
+  const aborted: ProofOutcome = {
+    status: 'aborted',
+    gate: 'g',
+    proof: 'p',
+    expected: 'green',
+    error: { code: 'mutation-apply-failed', message: 'cannot apply' },
+    workerPid: 10,
+  };
+
+  const outcome = verifyProofRestoration(aborted, { kind: 'stale', why: 'workspace changed' }, 10);
+
+  assert.equal(outcome.status, 'aborted');
+  if (outcome.status !== 'aborted') throw new Error('expected an aborted proof');
+  assert.equal(outcome.error.code, 'workspace-not-restored');
+  assert.equal(canReuseWorkspace(outcome), false);
+  assert.equal(canReuseWorkspace(aborted), true);
 });

--- a/tests/proof.test.ts
+++ b/tests/proof.test.ts
@@ -8,6 +8,7 @@ import {
   fail,
   pass,
   proof,
+  proofEstablished,
   refuse,
   runGate,
   runProof,
@@ -110,9 +111,9 @@ test('RED proof proves when its mutation breaches the target, then restores the 
   const outcome = await runProof(gateOver(state), proof.red(R1, 'prove R1', breachRule(state, 'r1')), '/project');
 
   assert.equal(outcome.status, 'completed');
-  assert.equal(outcome.ok, true);
+  assert.equal(proofEstablished(outcome), true);
   assert.deepEqual(outcome.status === 'completed' && outcome.reason, { kind: 'proved', target: 'r1' });
-  assert.equal(outcome.result?.verdict, 'fail');
+  assert.equal(outcome.status === 'completed' && outcome.result.verdict, 'fail');
   assert.deepEqual(state.log, ['apply r1', 'undo r1']);
   assert.deepEqual(state.breached, []);
 });
@@ -122,9 +123,9 @@ test('RED proof does not pass when the Gate fails for another Rule', async () =>
   const outcome = await runProof(gateOver(state), proof.red(R1, 'prove R1', breachRule(state, 'r2')), '/project');
 
   assert.equal(outcome.status, 'completed');
-  assert.equal(outcome.ok, false);
+  assert.equal(proofEstablished(outcome), false);
   assert.deepEqual(outcome.status === 'completed' && outcome.reason, { kind: 'target-rule-not-breached', target: 'r1', breached: ['r2'] });
-  assert.equal(outcome.result?.verdict, 'fail');
+  assert.equal(outcome.status === 'completed' && outcome.result.verdict, 'fail');
   assert.deepEqual(state.log, ['apply r2', 'undo r2']);
 });
 
@@ -133,9 +134,9 @@ test('RED proof does not pass when its target was already breached before mutati
   const outcome = await runProof(gateOver(state), proof.red(R1, 'prove R1 causally', breachRule(state, 'r1')), '/project');
 
   assert.equal(outcome.status, 'completed');
-  assert.equal(outcome.ok, false);
+  assert.equal(proofEstablished(outcome), false);
   assert.deepEqual(outcome.status === 'completed' && outcome.reason, { kind: 'target-already-breached', target: 'r1', breached: ['r1'] });
-  assert.equal(outcome.result?.verdict, 'fail');
+  assert.equal(outcome.status === 'completed' && outcome.result.verdict, 'fail');
   assert.deepEqual(state.log, [], 'the mutation must never be applied');
   assert.equal(state.contexts.length, 1, 'only the baseline Check runs');
 });
@@ -144,12 +145,12 @@ test('GREEN passes on PASS and REFUSE passes on REFUSE, and both restore', async
   const state = world();
   const green = await runProof(gateOver(state), proof.green('stays green'), '/project');
   assert.equal(green.status, 'completed');
-  assert.equal(green.ok, true);
+  assert.equal(proofEstablished(green), true);
 
   const refused = await runProof(gateOver(state), proof.refuse('refuses', setFlag(state, 'refused')), '/project');
   assert.equal(refused.status, 'completed');
-  assert.equal(refused.ok, true);
-  assert.equal(refused.result?.verdict, 'refuse');
+  assert.equal(proofEstablished(refused), true);
+  assert.equal(refused.status === 'completed' && refused.result.verdict, 'refuse');
   assert.equal(state.refused, false);
 });
 
@@ -161,11 +162,10 @@ test('a mutation that cannot be applied yields mutation-apply-failed and undoes 
     '/project',
   );
 
-  assert.equal(outcome.status, 'error');
-  if (outcome.status !== 'error') throw new Error('expected infrastructure error');
+  assert.equal(outcome.status, 'aborted');
+  if (outcome.status !== 'aborted') throw new Error('expected an aborted proof');
   assert.equal(outcome.error.code, 'mutation-apply-failed');
   assert.match(outcome.error.detail ?? '', /cannot apply/);
-  assert.equal(outcome.result, undefined);
   assert.deepEqual(state.log, ['apply r1', 'undo r1']);
   assert.deepEqual(state.breached, []);
 });
@@ -174,8 +174,8 @@ test('a Check that throws after mutation yields check-threw, and the mutation is
   const state = world();
   const outcome = await runProof(gateOver(state), proof.green('sees the throw', setFlag(state, 'checkThrows')), '/project');
 
-  assert.equal(outcome.status, 'error');
-  if (outcome.status !== 'error') throw new Error('expected infrastructure error');
+  assert.equal(outcome.status, 'aborted');
+  if (outcome.status !== 'aborted') throw new Error('expected an aborted proof');
   assert.equal(outcome.error.code, 'check-threw');
   assert.doesNotMatch(outcome.error.message, /baseline/);
   assert.match(outcome.error.detail ?? '', /check exploded/);
@@ -187,8 +187,8 @@ test('a baseline Check that throws blocks a RED proof before any mutation', asyn
   const state = world({ checkThrows: true });
   const outcome = await runProof(gateOver(state), proof.red(R1, 'prove R1', breachRule(state, 'r1')), '/project');
 
-  assert.equal(outcome.status, 'error');
-  if (outcome.status !== 'error') throw new Error('expected infrastructure error');
+  assert.equal(outcome.status, 'aborted');
+  if (outcome.status !== 'aborted') throw new Error('expected an aborted proof');
   assert.equal(outcome.error.code, 'check-threw');
   assert.match(outcome.error.message, /baseline/);
   assert.deepEqual(state.log, []);
@@ -198,11 +198,11 @@ test('an undo that fails yields mutation-restore-failed and keeps the Check resu
   const state = world();
   const outcome = await runProof(gateOver(state), proof.green('undo fails', setFlag(state, 'refused', true)), '/project');
 
-  assert.equal(outcome.status, 'error');
-  if (outcome.status !== 'error') throw new Error('expected infrastructure error');
+  assert.equal(outcome.status, 'unrestored');
+  if (outcome.status !== 'unrestored') throw new Error('expected an unrestored proof');
   assert.equal(outcome.error.code, 'mutation-restore-failed');
   assert.match(outcome.error.detail ?? '', /undo of refused exploded/);
-  assert.equal(outcome.result?.verdict, 'refuse');
+  assert.equal(outcome.result.verdict, 'refuse');
 });
 
 test('a Check that throws and an undo that fails yields mutation-restore-failed without a result', async () => {
@@ -213,10 +213,9 @@ test('a Check that throws and an undo that fails yields mutation-restore-failed 
     '/project',
   );
 
-  assert.equal(outcome.status, 'error');
-  if (outcome.status !== 'error') throw new Error('expected infrastructure error');
+  assert.equal(outcome.status, 'aborted');
+  if (outcome.status !== 'aborted') throw new Error('expected an aborted proof');
   assert.equal(outcome.error.code, 'mutation-restore-failed');
   assert.match(outcome.error.message, /Check threw/);
   assert.match(outcome.error.detail ?? '', /undo of checkThrows exploded/);
-  assert.equal(outcome.result, undefined);
 });

--- a/tests/reporter.core.test.ts
+++ b/tests/reporter.core.test.ts
@@ -57,7 +57,7 @@ test('a diagnostic without a line never asks for source', () => {
 });
 
 function completed(expected: 'red' | 'green' | 'refuse', reason: Extract<ProofOutcome, { status: 'completed' }>['reason'], result: CheckResult): ProofOutcome {
-  return { status: 'completed', gate: 'lint', proof: 'a var is flagged', expected, ok: reason.kind === 'proved', reason, result, workerPid: 1 };
+  return { status: 'completed', gate: 'lint', proof: 'a var is flagged', expected, reason, result, workerPid: 1 };
 }
 
 test('a proof line says why it was judged as it was', () => {

--- a/tests/reporter.core.test.ts
+++ b/tests/reporter.core.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { breach, counting, defineAdapter, defineGate, fail, formatProof, pass, refuse, type CheckResult, type ProofOutcome, type Scan } from 'redproof';
+import { breach, counting, defineAdapter, defineGate, fail, formatProof, pass, refuse, type CheckResult, type CompletedProofOutcome, type ProofOutcome, type Scan } from 'redproof';
 import type { CheckProjectRun } from '../packages/redproof/src/run/core/run.ts';
 import { renderRun } from '../packages/redproof/src/reporter/core/terminal.ts';
 
@@ -56,8 +56,12 @@ test('a diagnostic without a line never asks for source', () => {
   assert.doesNotMatch(output, /ignored/);
 });
 
-function completed(expected: 'red' | 'green' | 'refuse', reason: Extract<ProofOutcome, { status: 'completed' }>['reason'], result: CheckResult): ProofOutcome {
-  return { status: 'completed', gate: 'lint', proof: 'a var is flagged', expected, reason, result, workerPid: 1 };
+function completed<E extends CompletedProofOutcome['expected']>(
+  expected: E,
+  reason: Extract<CompletedProofOutcome, { expected: E }>['reason'],
+  result: CheckResult,
+): ProofOutcome {
+  return { status: 'completed', gate: 'lint', proof: 'a var is flagged', expected, reason, result, workerPid: 1 } as CompletedProofOutcome;
 }
 
 test('a proof line says why it was judged as it was', () => {

--- a/tests/reporter/model.test.ts
+++ b/tests/reporter/model.test.ts
@@ -3,6 +3,8 @@ import test from 'node:test';
 import {
   breach,
   buildGateReportModel,
+  countBreachedRules,
+  countBreaches,
   counting,
   defineAdapter,
   fail,
@@ -45,6 +47,18 @@ test('report model does not claim unknown Rules hold for non-countable failures'
     ['r1', 'breached'],
     ['r2', 'unknown'],
   ]);
+  assert.deepEqual(summarizeGateReports([model]).breaches, { kind: 'not-countable' });
+});
+
+test('a breached Rule carries its breaches inside the breached state', () => {
+  const first = breach(R1.id, { code: 'r1', message: 'first', location: null });
+  const second = breach(R1.id, { code: 'r1', message: 'second', location: null });
+  const model = buildGateReportModel(adapter(), fail(scan, [first, second]));
+
+  assert.deepEqual(model.rules[0]?.state, { kind: 'breached', breaches: [first, second] });
+  assert.deepEqual(model.rules[1]?.state, { kind: 'held' });
+  assert.equal(countBreachedRules(model), 1);
+  assert.equal(countBreaches(model), 2);
 });
 
 test('run summary is derived from Gate report models without I/O', () => {
@@ -65,7 +79,6 @@ test('run summary is derived from Gate report models without I/O', () => {
     undecidedRules: 2,
     unknownRules: 0,
     totalRules: 6,
-    breaches: 1,
-    exactBreachCount: true,
+    breaches: { kind: 'exact', count: 1 },
   });
 });

--- a/tests/reporter/prove-json.test.ts
+++ b/tests/reporter/prove-json.test.ts
@@ -19,7 +19,6 @@ test('prove JSON distinguishes proved and infrastructure-error outcomes', () => 
         gate: 'architecture',
         proof: 'detects forbidden import',
         expected: 'red',
-        ok: true,
         reason: { kind: 'proved', target: 'architecture/no-infra' },
         result: {
           verdict: 'fail',
@@ -34,11 +33,10 @@ test('prove JSON distinguishes proved and infrastructure-error outcomes', () => 
         workerPid: 10,
       },
       {
-        status: 'error',
+        status: 'aborted',
         gate: 'workspace',
         proof: 'restores mutation',
         expected: 'green',
-        ok: false,
         workerPid: 11,
         error: {
           code: 'workspace-not-restored',
@@ -71,7 +69,6 @@ test('prove JSON says why a proof was judged and what the Check found', () => {
         gate: 'lint',
         proof: 'a var in src is flagged',
         expected: 'red',
-        ok: false,
         reason: { kind: 'target-rule-not-breached', target: 'lint/no-var', breached: ['lint/no-let'] },
         result: {
           verdict: 'fail',
@@ -85,7 +82,6 @@ test('prove JSON says why a proof was judged and what the Check found', () => {
         gate: 'policy',
         proof: 'refuses without input',
         expected: 'refuse',
-        ok: true,
         reason: { kind: 'proved' },
         result: { verdict: 'refuse', scan, why: { code: 'unavailable', message: 'No input', location: null } },
         workerPid: 1,

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { readFile, stat } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import test from 'node:test';
-import { checkProject, loadProject, proveProject } from 'redproof';
+import { checkProject, loadProject, proofEstablished, proveProject } from 'redproof';
 
 const configOf = (name: string) => resolve(`fixtures/${name}/redproof.config.ts`);
 
@@ -29,7 +29,7 @@ test('in-place mode runs in the coordinator process and UndoMutation restores th
   const proof = await proveProject(config);
   assert.equal(proof.exitCode, 0);
   assert.equal(proof.outcomes.length, 2);
-  assert.ok(proof.outcomes.every(outcome => outcome.status === 'completed' && outcome.ok));
+  assert.ok(proof.outcomes.every(proofEstablished));
   assert.equal(await readFile(source, 'utf8'), before);
 });
 
@@ -57,7 +57,7 @@ test('copies mode reuses one Gate copy across proofs but returns to the baseline
 
   assert.equal(run.exitCode, 0);
   assert.deepEqual(
-    run.outcomes.map(outcome => [outcome.proof, outcome.status, outcome.ok]),
+    run.outcomes.map(outcome => [outcome.proof, outcome.status, proofEstablished(outcome)]),
     [
       ['first RED reuses the Gate copy', 'completed', true],
       ['second RED starts from the same clean baseline', 'completed', true],
@@ -77,11 +77,11 @@ test('copies mode rejects a proof when UndoMutation leaves the Gate copy stale',
   assert.equal(run.exitCode, 1);
   assert.equal(run.outcomes.length, 1, 'the stale Gate copy must not be reused for later proofs');
   const outcome = run.outcomes[0]!;
-  assert.equal(outcome.status, 'error');
-  if (outcome.status !== 'error') throw new Error('expected infrastructure error');
+  assert.equal(outcome.status, 'unrestored');
+  if (outcome.status !== 'unrestored') throw new Error('expected an unrestored proof');
   assert.equal(outcome.error.code, 'workspace-not-restored');
   assert.match(outcome.error.detail ?? '', /modified src\/state\.txt/);
-  assert.equal(outcome.result?.verdict, 'fail');
+  assert.equal(outcome.result.verdict, 'fail');
   assert.equal(await readFile(source, 'utf8'), before, 'the original workspace must stay untouched');
 
   await assert.rejects(stat(resolve('fixtures/execution-copies-stale/.redproof')));

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -17,6 +17,7 @@ import {
   type Breach,
   type Check,
   type CheckResult,
+  type CompletedProofOutcome,
   type Diagnostic,
   type ExecutionConfig,
   type Scan,
@@ -83,6 +84,23 @@ void badRefuse;
 // @ts-expect-error Breach must name one Rule.
 const rulelessBreach: Breach<'r1'> = diagnostic;
 void rulelessBreach;
+
+const judged = { status: 'completed', gate: 'g', proof: 'p', result: { verdict: 'pass', scan }, workerPid: 1 } as const;
+
+const provedRed: CompletedProofOutcome = { ...judged, expected: 'red', reason: { kind: 'proved', target: 'r1' } };
+void provedRed;
+
+// @ts-expect-error A proved RED proof names the Rule it breached.
+const targetlessRed: CompletedProofOutcome = { ...judged, expected: 'red', reason: { kind: 'proved' } };
+void targetlessRed;
+
+// @ts-expect-error Only a RED proof can find its target already breached.
+const greenWithTarget: CompletedProofOutcome = { ...judged, expected: 'green', reason: { kind: 'target-already-breached', target: 'r1', breached: ['r1'] } };
+void greenWithTarget;
+
+// @ts-expect-error A verdict mismatch cannot report the verdict it expected.
+const sameVerdict: CompletedProofOutcome = { ...judged, expected: 'green', reason: { kind: 'verdict-mismatch', expected: 'pass', actual: 'pass' } };
+void sameVerdict;
 
 // @ts-expect-error Diagnostic location is required, even when null.
 const missingLocation: Diagnostic = { code: 'x', message: 'x' };


### PR DESCRIPTION
## Problem

`CompletedProofOutcome` stored `ok` beside `reason`, so an outcome could say
`ok: true` with a reason of `verdict-mismatch`. `InfrastructureProofOutcome`
carried an optional `result` that only the `restore` step filled in.
`baselineOutcome` accepted any `Proof` and wrote `''` as the target when it
was not red. One `ProofEvaluation` served every proof kind, so a proved RED
proof had an optional `target` and a GREEN proof could carry a RED-only
reason.

The report model had the same shape. `GateReportModel` stored
`breachedRules` and `breachCount` beside the `rules` they came from.
`RunSummary` stored `exactBreachCount` beside `breaches`. A `held` Rule could
carry breaches, and the per-Rule `count` was `null` to repeat the Gate-level
`counting` fact.

## Fix

Proof outcomes: split the error outcome into `aborted` and `unrestored`.
An `aborted` outcome has no `result`. An `unrestored` outcome has a `result`
and only a restoration error code. Remove `ok`; `proofEstablished(outcome)`
replaces it. Narrow `baselineBlocksProof` and `baselineOutcome` to `RedProof`.
Give RED, GREEN, and REFUSE proofs their own evaluation types, and make a
completed outcome a union keyed by `expected`.

Report model: move the breaches into the `breached` state as a
`NonEmptyList<Breach>`. Replace the stored counts with `countBreachedRules`
and `countBreaches`. Make the summary total a `BreachTotal` union,
`exact` or `not-countable`.

Breaking: `status: 'error'` is now `'aborted' | 'unrestored'`; `ok`,
`RuleReport.breaches`, `breachedRules`, `breachCount`, and
`exactBreachCount` are gone. The JSON check and prove reports are unchanged.
Version set to 0.9.0.

## Verification

`npm run check` exits 0: typecheck, 202 tests, fixtures, and the five
self-hosted Gates with 26 proofs.

Two new tests and three type proofs, each red-proofed:

- A stale workspace after an aborted proof stays aborted. With the aborted
  branch returning its input unchanged: `actual: 'mutation-apply-failed'`,
  `expected: 'workspace-not-restored'`. Restored, green.
- A non-countable failure gives a `not-countable` summary. With the
  `countable = false` line removed: `actual: { kind: 'exact', count: 1 }`,
  `expected: { kind: 'not-countable' }`. Restored, green.
- `tests/types.ts` pins three illegal outcomes behind `@ts-expect-error`:
  a proved RED proof without a target, a GREEN proof with
  `target-already-breached`, and a mismatch whose `actual` equals
  `expected`. With one directive removed, `tsc` reports TS2322 on that
  line. Restored, green.