### PR TITLE
Detect flaky tests from retry evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ REFUSE   the Check could not decide safely
 
 You do not need to build every Gate yourself.
 
-- **[`@redproof/testing`](https://github.com/schalermthai/redproof/blob/main/docs/adapters.md#testing)** — test suites, skipped tests, TODO tests; supports Jest-compatible JSON and JUnit XML
+- **[`@redproof/testing`](https://github.com/schalermthai/redproof/blob/main/docs/adapters.md#testing)** — test suites, flaky tests, skipped tests, TODO tests; supports Jest-compatible JSON and JUnit XML
 - **[`@redproof/eslint`](https://github.com/schalermthai/redproof/blob/main/docs/adapters.md#eslint)** — selected ESLint rules as Redproof Rules
 - **[`@redproof/dependency-cruiser`](https://github.com/schalermthai/redproof/blob/main/docs/adapters.md#dependency-cruiser)** — architecture and dependency boundaries
 - **[`@redproof/stryker`](https://github.com/schalermthai/redproof/blob/main/docs/adapters.md#stryker)** — mutation detection and mutation-score policies

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -81,9 +81,11 @@ The testing integration can expose these Rules, depending on the selected report
 - `testing/no-skipped-tests`
 - `testing/no-todo-tests`
 
-The flaky-test Rule treats an ultimately passing assertion with retained failure
-messages as flaky. Vitest preserves that evidence for earlier retry attempts in
-its Jest-compatible JSON report. JUnit XML records only the final outcome, so
+The flaky-test Rule breaches when a test passes only after a retry. The evidence
+differs by producer. Vitest keeps the failure messages of earlier attempts in
+its Jest-compatible JSON report. Jest clears them, reports `invocations` greater
+than 1, and fills `retryReasons` only when `logErrorsBeforeRetry` is set.
+Redproof reads all three signals. JUnit XML records only the final outcome, so
 Redproof refuses `noFlakyTests` with that format at composition time.
 
 ### Other test runners

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -23,6 +23,7 @@ import { defineGate, defineProofs, mutate, proof } from 'redproof';
 const adapter = vitest({
   rules: {
     testsPass: true,
+    noFlakyTests: true,
     noSkippedTests: true,
     noTodoTests: true,
   },
@@ -76,8 +77,14 @@ with `workspace-not-restored`. The adapter is proven against Vitest 5.
 The testing integration can expose these Rules, depending on the selected report format:
 
 - `testing/tests-pass`
+- `testing/no-flaky-tests` (Jest-compatible JSON only)
 - `testing/no-skipped-tests`
 - `testing/no-todo-tests`
+
+The flaky-test Rule treats an ultimately passing assertion with retained failure
+messages as flaky. Vitest preserves that evidence for earlier retry attempts in
+its Jest-compatible JSON report. JUnit XML records only the final outcome, so
+Redproof refuses `noFlakyTests` with that format at composition time.
 
 ### Other test runners
 

--- a/fixtures/testing-vitest/gates/tests.ts
+++ b/fixtures/testing-vitest/gates/tests.ts
@@ -7,6 +7,7 @@ const adapter = vitest({
   reportFile: 'results.json',
   rules: {
     testsPass: true,
+    noFlakyTests: true,
     noSkippedTests: true,
     noTodoTests: true,
   },
@@ -21,6 +22,18 @@ export const proofs = defineProofs(gate, [
     mutate.replaceText(
       locate.text({ files: 'project/src/calculator.js', find: 'return left + right;' }),
       'return left - right;',
+    ),
+  ),
+  proof.red(
+    adapter.rules.noFlakyTests,
+    'detects a test that passes only after retrying',
+    mutate.replaceText(
+      locate.text({ files: 'project/test/calculator.test.js', find: '// REDPROOF_FLAKY_SLOT' }),
+      `let attempts = 0;
+test('eventually passes', { retry: 1 }, () => {
+  attempts += 1;
+  expect(attempts).toBe(2);
+});`,
     ),
   ),
   proof.red(

--- a/fixtures/testing-vitest/project/test/calculator.test.js
+++ b/fixtures/testing-vitest/project/test/calculator.test.js
@@ -7,4 +7,5 @@ describe('calculator', () => {
   });
 
   // REDPROOF_TODO_SLOT
+  // REDPROOF_FLAKY_SLOT
 });

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -41,8 +41,8 @@ same file as the config `outputFile`. Redproof restores any pre-existing report
 afterward. Omit `reportFile` to use Redproof's private temporary report.
 
 `noFlakyTests` is available for Jest-compatible JSON reports. It breaches when
-a test ultimately passes but the report retains failures from earlier retry
-attempts.
+a test passes only after a retry. Vitest keeps the earlier failure messages in
+the report. Jest reports `invocations` greater than 1. Redproof reads both.
 
 Then run:
 

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -25,6 +25,7 @@ const adapter = vitest({
   reportFile: 'test-results.json',
   rules: {
     testsPass: true,
+    noFlakyTests: true,
     noSkippedTests: true,
     noTodoTests: true,
   },
@@ -38,6 +39,10 @@ export default defineGate({ id: 'unit-tests', adapter });
 to inspect the same fresh report. It is relative to `cwd` and must name the
 same file as the config `outputFile`. Redproof restores any pre-existing report
 afterward. Omit `reportFile` to use Redproof's private temporary report.
+
+`noFlakyTests` is available for Jest-compatible JSON reports. It breaches when
+a test ultimately passes but the report retains failures from earlier retry
+attempts.
 
 Then run:
 

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -64,15 +64,24 @@ function normalizeRun(root: string, run: TestRun): TestRun {
   };
 }
 
-const TEST_RULE_NAMES = ['testsPass', 'noSkippedTests', 'noTodoTests'] as const;
+const TEST_RULE_NAMES = ['testsPass', 'noFlakyTests', 'noSkippedTests', 'noTodoTests'] as const;
 
 export function testing<const O extends TestRuleOptions>(
   options: TestingAdapterOptions<O> & { readonly rules: NoUnknownKeys<O, TestRuleOptions> },
 ): Adapter<TestRuleCatalog<O>> {
   rejectUnknownKeys(options.rules, TEST_RULE_NAMES, 'testing rule');
 
-  if (!options.rules.testsPass && !options.rules.noSkippedTests && !options.rules.noTodoTests) {
+  if (
+    !options.rules.testsPass
+    && !options.rules.noFlakyTests
+    && !options.rules.noSkippedTests
+    && !options.rules.noTodoTests
+  ) {
     throw new Error('Testing adapter requires at least one Redproof rule.');
+  }
+
+  if (options.rules.noFlakyTests && !options.report.capabilities.flaky) {
+    throw new Error(`Report format ${options.report.kind} cannot distinguish flaky tests.`);
   }
 
   if (options.rules.noTodoTests && !options.report.capabilities.todo) {
@@ -84,6 +93,12 @@ export function testing<const O extends TestRuleOptions>(
     catalog.testsPass = {
       id: 'testing/tests-pass',
       description: 'All tests must pass.',
+    };
+  }
+  if (options.rules.noFlakyTests) {
+    catalog.noFlakyTests = {
+      id: 'testing/no-flaky-tests',
+      description: 'Tests must pass without failed attempts.',
     };
   }
   if (options.rules.noSkippedTests) {
@@ -194,6 +209,7 @@ export function testing<const O extends TestRuleOptions>(
             scan,
             testRunBreaches(run, {
               ...(options.rules.testsPass ? { testsPass: byAlias.testsPass! } : {}),
+              ...(options.rules.noFlakyTests ? { noFlakyTests: byAlias.noFlakyTests! } : {}),
               ...(options.rules.noSkippedTests ? { noSkippedTests: byAlias.noSkippedTests! } : {}),
               ...(options.rules.noTodoTests ? { noTodoTests: byAlias.noTodoTests! } : {}),
             }),

--- a/packages/testing/src/model.ts
+++ b/packages/testing/src/model.ts
@@ -34,6 +34,7 @@ export type TestRun = {
 
 export type TestRuleOptions = {
   readonly testsPass?: true;
+  readonly noFlakyTests?: true;
   readonly noSkippedTests?: true;
   readonly noTodoTests?: true;
 };
@@ -42,15 +43,19 @@ export type TestRuleCatalog<O extends TestRuleOptions> = {
   readonly [K in keyof O]:
     K extends 'testsPass'
       ? Rule<'testing/tests-pass'>
-      : K extends 'noSkippedTests'
-        ? Rule<'testing/no-skipped-tests'>
-        : K extends 'noTodoTests'
-          ? Rule<'testing/no-todo-tests'>
-          : never;
+      : K extends 'noFlakyTests'
+        ? Rule<'testing/no-flaky-tests'>
+        : K extends 'noSkippedTests'
+          ? Rule<'testing/no-skipped-tests'>
+          : K extends 'noTodoTests'
+            ? Rule<'testing/no-todo-tests'>
+            : never;
 };
 
 export type TestReportCapabilities = {
   readonly todo: boolean;
+  /** Whether a passing test preserves failure evidence from earlier attempts. */
+  readonly flaky?: boolean;
 };
 
 export type TestReportFormat = {
@@ -114,6 +119,7 @@ export function testRunBreaches<R extends RuleRef>(
   run: TestRun,
   rules: {
     readonly testsPass?: Rule<R>;
+    readonly noFlakyTests?: Rule<R>;
     readonly noSkippedTests?: Rule<R>;
     readonly noTodoTests?: Rule<R>;
   },
@@ -125,6 +131,15 @@ export function testRunBreaches<R extends RuleRef>(
       breaches.push(breach(
         rules.testsPass,
         testDiagnostic(test, 'test-failed', displayName(test)),
+      ));
+    }
+  }
+
+  if (rules.noFlakyTests) {
+    for (const test of run.tests.filter(item => item.status === 'passed' && item.failure)) {
+      breaches.push(breach(
+        rules.noFlakyTests,
+        testDiagnostic(test, 'test-flaky', displayName(test)),
       ));
     }
   }

--- a/packages/testing/src/reports/jest-json.ts
+++ b/packages/testing/src/reports/jest-json.ts
@@ -82,7 +82,7 @@ export function jestJson(): TestReportFormat {
   return {
     kind: 'jest-json',
     extension: '.json',
-    capabilities: { todo: true },
+    capabilities: { todo: true, flaky: true },
     parse: parseJestJson,
   };
 }

--- a/packages/testing/src/reports/jest-json.ts
+++ b/packages/testing/src/reports/jest-json.ts
@@ -7,6 +7,9 @@ type JestAssertionLike = {
   readonly title?: string;
   readonly duration?: number | null;
   readonly failureMessages?: readonly string[];
+  /** Jest fills retryReasons only with logErrorsBeforeRetry; invocations counts every attempt. */
+  readonly retryReasons?: readonly string[];
+  readonly invocations?: number;
   readonly location?: {
     readonly line?: number;
     readonly column?: number;
@@ -55,6 +58,11 @@ export function parseJestJson(input: string): TestRun {
     for (const assertion of file.assertionResults) {
       const status = statusOf(assertion.status);
       const failureMessage = assertion.failureMessages?.filter(Boolean).join('\n\n');
+      const retryReasons = assertion.retryReasons?.filter(Boolean).join('\n\n');
+      const retried = typeof assertion.invocations === 'number' && assertion.invocations > 1;
+      const evidence = failureMessage
+        || retryReasons
+        || (retried ? `passed after ${assertion.invocations} invocations` : '');
       const line = assertion.location?.line ?? null;
       const column = assertion.location?.column ?? null;
       const location = file.name
@@ -68,8 +76,8 @@ export function parseJestJson(input: string): TestRun {
         status,
         location,
         ...(typeof assertion.duration === 'number' ? { durationMs: assertion.duration } : {}),
-        ...(failureMessage
-          ? { failure: { message: failureMessage } }
+        ...(evidence
+          ? { failure: { message: evidence } }
           : {}),
       });
     }

--- a/packages/testing/src/reports/junit-xml.ts
+++ b/packages/testing/src/reports/junit-xml.ts
@@ -86,7 +86,7 @@ export function junitXml(): TestReportFormat {
   return {
     kind: 'junit-xml',
     extension: '.xml',
-    capabilities: { todo: false },
+    capabilities: { todo: false, flaky: false },
     parse: parseJunitXml,
   };
 }

--- a/scripts/verify-package.ts
+++ b/scripts/verify-package.ts
@@ -241,7 +241,7 @@ try {
     + "export const check = command({ rule, command: 'node' });\n"
     + "export const group = commands({ entries: [{ rule, command: 'node' }] });\n"
     + "export const mutation = stryker({ cwd: 'packages/parser', rules: { noNewUndetectedMutants: { acceptedMutantsFile: 'accepted-mutants.json' } } });\n"
-    + "export const tests = vitest({ cwd: 'packages/parser', reportFile: 'results.json', rules: { testsPass: true } });\n"
+    + "export const tests = vitest({ cwd: 'packages/parser', reportFile: 'results.json', rules: { testsPass: true, noFlakyTests: true } });\n"
     + "export const gate = defineGate;\n";
   await writeFile(join(consumer, 'consumer.ts'), green);
   const typesOk = tryRun(tsc, ['-p', 'tsconfig.json'], consumer);

--- a/tests/adapters/integration.test.ts
+++ b/tests/adapters/integration.test.ts
@@ -48,6 +48,7 @@ test('Vitest adapter preserves a nested project report while proving test polici
       ['red', true, 'fail'],
       ['red', true, 'fail'],
       ['red', true, 'fail'],
+      ['red', true, 'fail'],
       ['green', true, 'pass'],
       ['refuse', true, 'refuse'],
     ],

--- a/tests/adapters/testing.test.ts
+++ b/tests/adapters/testing.test.ts
@@ -49,6 +49,20 @@ const jestSample = JSON.stringify({
   ],
 });
 
+const flakyJestSample = JSON.stringify({
+  success: true,
+  testResults: [{
+    name: '/workspace/test/retry.test.ts',
+    assertionResults: [{
+      ancestorTitles: ['retry'],
+      title: 'eventually passes',
+      status: 'passed',
+      failureMessages: ['expected attempt 1 to succeed'],
+      location: { line: 8, column: 3 },
+    }],
+  }],
+});
+
 const junitSample = `<?xml version="1.0" encoding="utf-8"?>
 <testsuites name="pytest tests">
   <testsuite name="pytest" failures="1" skipped="1" tests="3">
@@ -122,7 +136,24 @@ test('generic test semantics map statuses to distinct Redproof rules', () => {
   ]);
 });
 
-test('JUnit refuses noTodoTests at composition time because the format cannot distinguish TODO', () => {
+test('Jest-compatible retry evidence maps an ultimately passing test to noFlakyTests', () => {
+  const noFlakyTests = defineRule({
+    id: 'testing/no-flaky-tests',
+    description: 'tests pass on their first attempt',
+  });
+  const run = parseJestJson(flakyJestSample);
+
+  assert.equal(run.tests[0]?.status, 'passed');
+  assert.equal(run.tests[0]?.failure?.message, 'expected attempt 1 to succeed');
+  const breaches = testRunBreaches(run, { noFlakyTests });
+  assert.equal(breaches.length, 1);
+  assert.equal(breaches[0]?.rule, 'testing/no-flaky-tests');
+  assert.equal(breaches[0]?.code, 'test-flaky');
+  assert.equal(breaches[0]?.detail, 'expected attempt 1 to succeed');
+  assert.equal(testRunBreaches(parseJestJson(jestSample), { noFlakyTests }).length, 0);
+});
+
+test('JUnit refuses rules for semantics its final-outcome format cannot distinguish', () => {
   const runner: TestRunner = {
     description: 'fake',
     async run() { return { kind: 'completed', exitCode: 0, stdout: '', stderr: '' }; },
@@ -133,6 +164,11 @@ test('JUnit refuses noTodoTests at composition time because the format cannot di
     report: report.junitXml(),
     rules: { noTodoTests: true },
   }), /cannot distinguish TODO tests/);
+  assert.throws(() => testing({
+    runner,
+    report: report.junitXml(),
+    rules: { noFlakyTests: true },
+  }), /cannot distinguish flaky tests/);
 });
 
 test('testing adapter trusts structured failures over the command exit code', async () => {
@@ -252,7 +288,7 @@ test('the testing adapter rejects a rule name it does not know', () => {
       report: report.junitXml(),
       rules: { testsPass: true, noPurpleTests: true } as never,
     }),
-    /Unknown testing rule option: "noPurpleTests"\. Known options: testsPass, noSkippedTests, noTodoTests\./,
+    /Unknown testing rule option: "noPurpleTests"\. Known options: testsPass, noFlakyTests, noSkippedTests, noTodoTests\./,
   );
 });
 

--- a/tests/adapters/testing.test.ts
+++ b/tests/adapters/testing.test.ts
@@ -63,6 +63,33 @@ const flakyJestSample = JSON.stringify({
   }],
 });
 
+const retriedJestSample = JSON.stringify({
+  success: true,
+  testResults: [{
+    name: '/workspace/test/retry.test.ts',
+    assertionResults: [
+      {
+        ancestorTitles: ['retry'],
+        title: 'eventually passes',
+        status: 'passed',
+        failureMessages: [],
+        retryReasons: [],
+        invocations: 2,
+        location: { line: 8, column: 3 },
+      },
+      {
+        ancestorTitles: ['retry'],
+        title: 'passes first time',
+        status: 'passed',
+        failureMessages: [],
+        retryReasons: [],
+        invocations: 1,
+        location: { line: 14, column: 3 },
+      },
+    ],
+  }],
+});
+
 const junitSample = `<?xml version="1.0" encoding="utf-8"?>
 <testsuites name="pytest tests">
   <testsuite name="pytest" failures="1" skipped="1" tests="3">
@@ -151,6 +178,23 @@ test('Jest-compatible retry evidence maps an ultimately passing test to noFlakyT
   assert.equal(breaches[0]?.code, 'test-flaky');
   assert.equal(breaches[0]?.detail, 'expected attempt 1 to succeed');
   assert.equal(testRunBreaches(parseJestJson(jestSample), { noFlakyTests }).length, 0);
+});
+
+test('Jest retry counts map a passing test with empty failure messages to noFlakyTests', () => {
+  const noFlakyTests = defineRule({
+    id: 'testing/no-flaky-tests',
+    description: 'tests pass on their first attempt',
+  });
+  const run = parseJestJson(retriedJestSample);
+
+  assert.deepEqual(run.tests.map(item => item.status), ['passed', 'passed']);
+  assert.equal(run.tests[0]?.failure?.message, 'passed after 2 invocations');
+  assert.equal(run.tests[1]?.failure, undefined);
+  const breaches = testRunBreaches(run, { noFlakyTests });
+  assert.equal(breaches.length, 1);
+  assert.equal(breaches[0]?.code, 'test-flaky');
+  assert.equal(breaches[0]?.message, 'retry > eventually passes');
+  assert.equal(breaches[0]?.detail, 'passed after 2 invocations');
 });
 
 test('JUnit refuses rules for semantics its final-outcome format cannot distinguish', () => {

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -236,6 +236,7 @@ baselineStryker.rules.mutationScore;
 const vitestAdapter = vitest({
   rules: {
     testsPass: true,
+    noFlakyTests: true,
     noSkippedTests: true,
   },
 });
@@ -247,11 +248,17 @@ proof.red(vitestAdapter.rules.noSkippedTests, 'no skipped tests proof', {
   description: 'noop',
   async apply() { return async () => {}; },
 });
+proof.red(vitestAdapter.rules.noFlakyTests, 'no flaky tests proof', {
+  description: 'noop',
+  async apply() { return async () => {}; },
+});
 
 const passOnlyVitest = vitest({ rules: { testsPass: true } });
 passOnlyVitest.rules.testsPass;
 // @ts-expect-error noSkippedTests is not exposed when the rule was not selected.
 passOnlyVitest.rules.noSkippedTests;
+// @ts-expect-error noFlakyTests is not exposed when the rule was not selected.
+passOnlyVitest.rules.noFlakyTests;
 
 vitest({
   cwd: 'packages/app',


### PR DESCRIPTION
Written by an AI agent on behalf of @schalermthai; it has not yet been reviewed by a human.

Stacked on #44 so the integration fixture can exercise Vitest package-root and configured-report behavior together. The implementation commit is focused on retry evidence and can be rebased onto `main` after #44 merges.

## Summary
- add opt-in `testing/no-flaky-tests` semantics for Jest-compatible JSON
- breach when a test ultimately passes but retains failure evidence from earlier attempts
- capability-gate the Rule so JUnit refuses it at composition time instead of claiming unsupported coverage
- add public types/docs, a causal Vitest retry proof, and packed-consumer coverage

## Expert battle test
Vitest’s native multi-project `test/unit/test/retry.test.ts` exits successfully. Redproof inspected 48 reported assertions and identified 39 retry-dependent passes with targeted `test-flaky` breaches.

## Verification
- `npm run check` (223/223 native tests, 4/4 self-Gates, 22/22 Rules, all self-proofs)
- `npm run verify:package`
- minimized Vitest fixture: clean check plus six RED/GREEN/REFUSE proofs