### PR TITLE
Refuse instead of throw when the configured Vitest report cannot be set aside or restored

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -68,9 +68,7 @@ relative to `cwd` and must name the same file as the JSON `outputFile` in the
 Vitest config. Keep the Vitest `root` at `cwd`. If the two disagree, the Check
 refuses because the report is not found. A keyed `outputFile` works when
 `reportFile` matches its `json` entry. When `reportFile` is absent, Redproof
-continues to direct Vitest to a private temporary JSON report. If the previous
-report cannot be set aside or restored, the Check refuses and names the backup
-file, so a file-system problem never looks like a test result.
+continues to direct Vitest to a private temporary JSON report.
 
 Redproof passes `--no-cache` to Vitest. Without it, Vitest writes a results
 cache under `node_modules/.vite` inside the project, and a proof run refuses

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -68,7 +68,9 @@ relative to `cwd` and must name the same file as the JSON `outputFile` in the
 Vitest config. Keep the Vitest `root` at `cwd`. If the two disagree, the Check
 refuses because the report is not found. A keyed `outputFile` works when
 `reportFile` matches its `json` entry. When `reportFile` is absent, Redproof
-continues to direct Vitest to a private temporary JSON report.
+continues to direct Vitest to a private temporary JSON report. If the previous
+report cannot be set aside or restored, the Check refuses and names the backup
+file, so a file-system problem never looks like a test result.
 
 Redproof passes `--no-cache` to Vitest. Without it, Vitest writes a results
 cache under `node_modules/.vite` inside the project, and a proof run refuses

--- a/packages/testing/src/shell/vitest-runner.ts
+++ b/packages/testing/src/shell/vitest-runner.ts
@@ -13,6 +13,28 @@ function unavailable(message: string, detail: string): TestRunnerResult {
   return { kind: 'unavailable', message, detail };
 }
 
+function detailOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/** Remove the fresh report and put the previous one back. Null when both succeed. */
+async function restoreReport(reportFile: string, backup: string | null): Promise<TestRunnerResult | null> {
+  const removed = await rm(reportFile, { force: true }).catch((error: Error) => error);
+  const restored = backup === null
+    ? null
+    : await rename(backup, reportFile).catch((error: Error) => error);
+  if (restored instanceof Error) {
+    return unavailable(
+      `The previous Vitest report could not be restored from ${backup}.`,
+      restored.message,
+    );
+  }
+  if (removed instanceof Error) {
+    return unavailable('The fresh Vitest report could not be removed after the run.', removed.message);
+  }
+  return null;
+}
+
 async function copyReport(
   execution: TestRunnerCompleted,
   source: string,
@@ -22,10 +44,7 @@ async function copyReport(
     await copyFile(source, target);
     return execution;
   } catch (error) {
-    return unavailable(
-      'Vitest did not produce its configured JSON report.',
-      error instanceof Error ? error.message : String(error),
-    );
+    return unavailable('Vitest did not produce its configured JSON report.', detailOf(error));
   }
 }
 
@@ -74,18 +93,27 @@ export function configuredVitestReport(
         return unavailable('The configured Vitest report is a directory.', reportFile);
       }
 
-      const backup = `${reportFile}.redproof-backup-${randomUUID()}`;
-      const hadExisting = !(existing instanceof Error);
-      if (hadExisting) await rename(reportFile, backup);
+      const backup = existing instanceof Error
+        ? null
+        : `${reportFile}.redproof-backup-${randomUUID()}`;
+      if (backup !== null) {
+        const setAside = await rename(reportFile, backup).catch((error: Error) => error);
+        if (setAside instanceof Error) {
+          return unavailable('The previous Vitest report could not be set aside.', setAside.message);
+        }
+      }
 
+      let outcome: TestRunnerResult;
       try {
         const execution = await runner.run(ctx);
-        if (execution.kind === 'unavailable') return execution;
-        return await copyReport(execution, reportFile, ctx.reportFile);
-      } finally {
-        await rm(reportFile, { force: true });
-        if (hadExisting) await rename(backup, reportFile);
+        outcome = execution.kind === 'unavailable'
+          ? execution
+          : await copyReport(execution, reportFile, ctx.reportFile);
+      } catch (error) {
+        outcome = unavailable('The test command failed before Vitest reported.', detailOf(error));
       }
+
+      return await restoreReport(reportFile, backup) ?? outcome;
     },
   };
 }

--- a/tests/adapters/testing.test.ts
+++ b/tests/adapters/testing.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdir, readFile, realpath, symlink, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, readdir, readFile, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
@@ -451,6 +451,90 @@ test('a configured Vitest report refuses a stale file when the run writes nothin
     }
     assert.equal(await readFile(capturedReport, 'utf8').catch(() => null), null);
     assert.equal(await readFile(configuredReport, 'utf8'), 'stale report');
+  });
+});
+
+test('a configured Vitest report refuses when the previous file cannot be set aside', async () => {
+  await withWorkspace(async root => {
+    const project = join(root, 'project');
+    const configuredReport = join(project, 'results.json');
+    await mkdir(project);
+    await writeFile(configuredReport, 'previous report', 'utf8');
+    await chmod(project, 0o555);
+
+    let ran = false;
+    const fake: TestRunner = {
+      description: 'fake Vitest',
+      async run() {
+        ran = true;
+        return { kind: 'completed', exitCode: 0, stdout: '', stderr: '' };
+      },
+    };
+    const wrapped = configuredVitestReport(fake, { cwd: 'project', reportFile: 'results.json' });
+    try {
+      const result = await wrapped.run({ root, reportFile: join(root, 'captured.json') });
+      assert.equal(result.kind, 'unavailable');
+      if (result.kind === 'unavailable') {
+        assert.match(result.message, /could not be set aside/);
+      }
+      assert.equal(ran, false);
+    } finally {
+      await chmod(project, 0o755);
+    }
+    assert.equal(await readFile(configuredReport, 'utf8'), 'previous report');
+  });
+});
+
+test('a configured Vitest report refuses when the previous file cannot be restored', async () => {
+  await withWorkspace(async root => {
+    const project = join(root, 'project');
+    const configuredReport = join(project, 'results.json');
+    const capturedReport = join(root, 'captured.json');
+    await mkdir(project);
+    await writeFile(configuredReport, 'previous report', 'utf8');
+
+    const fake: TestRunner = {
+      description: 'fake Vitest that cleans its output directory',
+      async run() {
+        for (const name of await readdir(project)) {
+          if (name.includes('.redproof-backup-')) await rm(join(project, name));
+        }
+        await writeFile(configuredReport, jestSample, 'utf8');
+        return { kind: 'completed', exitCode: 0, stdout: '', stderr: '' };
+      },
+    };
+    const wrapped = configuredVitestReport(fake, { cwd: 'project', reportFile: 'results.json' });
+    const result = await wrapped.run({ root, reportFile: capturedReport });
+
+    assert.equal(result.kind, 'unavailable');
+    if (result.kind === 'unavailable') {
+      assert.match(result.message, /could not be restored/);
+      assert.match(result.message, /results\.json\.redproof-backup-/);
+    }
+  });
+});
+
+test('a configured Vitest report refuses and restores when the run throws', async () => {
+  await withWorkspace(async root => {
+    const project = join(root, 'project');
+    const configuredReport = join(project, 'results.json');
+    await mkdir(project);
+    await writeFile(configuredReport, 'previous report', 'utf8');
+
+    const fake: TestRunner = {
+      description: 'fake Vitest that crashes',
+      async run() {
+        throw new Error('spawn failed');
+      },
+    };
+    const wrapped = configuredVitestReport(fake, { cwd: 'project', reportFile: 'results.json' });
+    const result = await wrapped.run({ root, reportFile: join(root, 'captured.json') });
+
+    assert.equal(result.kind, 'unavailable');
+    if (result.kind === 'unavailable') {
+      assert.equal(result.detail, 'spawn failed');
+    }
+    assert.equal(await readFile(configuredReport, 'utf8'), 'previous report');
   });
 });
 


### PR DESCRIPTION
## Problem

`configuredVitestReport` moved the previous report aside with a bare `rename`, and put it back in a bare `finally`. Both sat outside any error handling. A read-only project directory threw `EACCES` out of the Check. A missing backup at restore time threw `ENOENT` and hid the real run result. A runner that threw escaped as a raw error. Redproof's rule is that a broken Check is a REFUSE, never a crash and never a verdict.

## Fix

The set-aside `rename` is caught and returns `unavailable` with "could not be set aside". The runner call is caught and returns `unavailable` with the error as detail. Restore runs after the try block and returns `unavailable` when the fresh report cannot be removed, or when the previous report cannot be put back. The restore message names the backup file so the user can recover it. A restore failure wins over the run outcome, because the workspace is no longer clean.

## Verification

Three tests were written first and were red before the fix:

- "refuses when the previous file cannot be set aside" threw `EACCES: permission denied, rename ...`
- "refuses when the previous file cannot be restored" threw `ENOENT: no such file or directory, rename ...`
- "refuses and restores when the run throws" threw `spawn failed`

After the fix all three pass and the previous report is intact in each case.

`npm run check`: exit 0. 228 of 228 tests. 4 of 4 self Gates, 22 of 22 Rules, 31 proofs established.