### PR TITLE
Refuse contradictory Jest-compatible reports

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -88,6 +88,10 @@ than 1, and fills `retryReasons` only when `logErrorsBeforeRetry` is set.
 Redproof reads all three signals. JUnit XML records only the final outcome, so
 Redproof refuses `noFlakyTests` with that format at composition time.
 
+When a Jest-compatible JSON report includes aggregate test counts, Redproof
+checks them against the contained assertions. A contradictory report refuses
+the Gate instead of producing a false PASS from incomplete result data.
+
 ### Other test runners
 
 You do not need a dedicated Redproof package for every test framework.

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -88,7 +88,7 @@ than 1, and fills `retryReasons` only when `logErrorsBeforeRetry` is set.
 Redproof reads all three signals. JUnit XML records only the final outcome, so
 Redproof refuses `noFlakyTests` with that format at composition time.
 
-When a Jest-compatible JSON report includes aggregate test counts, Redproof
+When a Jest-compatible JSON report includes total or failed test counts, Redproof
 checks them against the contained assertions. A contradictory report refuses
 the Gate instead of producing a false PASS from incomplete result data.
 

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -43,7 +43,7 @@ afterward. Omit `reportFile` to use Redproof's private temporary report.
 `noFlakyTests` is available for Jest-compatible JSON reports. It breaches when
 a test passes only after a retry. Vitest keeps the earlier failure messages in
 the report. Jest reports `invocations` greater than 1. Redproof reads both.
-Redproof also refuses a Jest-compatible report when its aggregate test counts
+Redproof also refuses a Jest-compatible report when its total or failed test counts
 contradict the contained assertions.
 
 Then run:

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -43,6 +43,8 @@ afterward. Omit `reportFile` to use Redproof's private temporary report.
 `noFlakyTests` is available for Jest-compatible JSON reports. It breaches when
 a test passes only after a retry. Vitest keeps the earlier failure messages in
 the report. Jest reports `invocations` greater than 1. Redproof reads both.
+Redproof also refuses a Jest-compatible report when its aggregate test counts
+contradict the contained assertions.
 
 Then run:
 

--- a/packages/testing/src/reports/jest-json.ts
+++ b/packages/testing/src/reports/jest-json.ts
@@ -22,8 +22,38 @@ type JestFileLike = {
 };
 
 type JestReportLike = {
+  readonly numTotalTests?: number;
+  readonly numPassedTests?: number;
+  readonly numFailedTests?: number;
+  readonly numPendingTests?: number;
+  readonly numTodoTests?: number;
   readonly testResults?: readonly JestFileLike[];
 };
+
+type JestSummaryField = Exclude<keyof JestReportLike, 'testResults'>;
+
+function validateSummary(parsed: JestReportLike, tests: readonly TestCase[]): void {
+  const expected: Readonly<Record<JestSummaryField, number>> = {
+    numTotalTests: tests.length,
+    numPassedTests: tests.filter(test => test.status === 'passed').length,
+    numFailedTests: tests.filter(test => test.status === 'failed').length,
+    numPendingTests: tests.filter(test => test.status === 'skipped').length,
+    numTodoTests: tests.filter(test => test.status === 'todo').length,
+  };
+
+  for (const field of Object.keys(expected) as JestSummaryField[]) {
+    const reported = parsed[field];
+    if (reported === undefined) continue;
+    if (!Number.isSafeInteger(reported) || reported < 0) {
+      throw new Error(`Jest-compatible JSON ${field} must be a non-negative safe integer.`);
+    }
+    if (reported !== expected[field]) {
+      throw new Error(
+        `Jest-compatible JSON ${field} is ${reported}, but assertionResults contain ${expected[field]}.`,
+      );
+    }
+  }
+}
 
 function statusOf(status: string | undefined): TestStatus {
   switch (status) {
@@ -83,6 +113,7 @@ export function parseJestJson(input: string): TestRun {
     }
   }
 
+  validateSummary(parsed, tests);
   return { tests };
 }
 

--- a/packages/testing/src/reports/jest-json.ts
+++ b/packages/testing/src/reports/jest-json.ts
@@ -32,22 +32,32 @@ type JestReportLike = {
 
 type JestSummaryField = Exclude<keyof JestReportLike, 'testResults'>;
 
-function validateSummary(parsed: JestReportLike, tests: readonly TestCase[]): void {
-  const expected: Readonly<Record<JestSummaryField, number>> = {
-    numTotalTests: tests.length,
-    numPassedTests: tests.filter(test => test.status === 'passed').length,
-    numFailedTests: tests.filter(test => test.status === 'failed').length,
-    numPendingTests: tests.filter(test => test.status === 'skipped').length,
-    numTodoTests: tests.filter(test => test.status === 'todo').length,
-  };
+const SUMMARY_FIELDS: readonly JestSummaryField[] = [
+  'numTotalTests',
+  'numPassedTests',
+  'numFailedTests',
+  'numPendingTests',
+  'numTodoTests',
+];
 
-  for (const field of Object.keys(expected) as JestSummaryField[]) {
+/** Only total and failed agree with assertionResults across Vitest versions and under bail. */
+function validateSummary(parsed: JestReportLike, tests: readonly TestCase[]): void {
+  for (const field of SUMMARY_FIELDS) {
     const reported = parsed[field];
     if (reported === undefined) continue;
     if (!Number.isSafeInteger(reported) || reported < 0) {
       throw new Error(`Jest-compatible JSON ${field} must be a non-negative safe integer.`);
     }
-    if (reported !== expected[field]) {
+  }
+
+  const expected = {
+    numTotalTests: tests.length,
+    numFailedTests: tests.filter(test => test.status === 'failed').length,
+  } as const;
+
+  for (const field of Object.keys(expected) as (keyof typeof expected)[]) {
+    const reported = parsed[field];
+    if (reported !== undefined && reported !== expected[field]) {
       throw new Error(
         `Jest-compatible JSON ${field} is ${reported}, but assertionResults contain ${expected[field]}.`,
       );

--- a/tests/adapters/testing.test.ts
+++ b/tests/adapters/testing.test.ts
@@ -191,17 +191,14 @@ test('Jest-compatible JSON validates its reported assertion totals', () => {
   };
   assert.equal(parseJestJson(JSON.stringify(complete)).tests.length, 4);
 
-  for (const field of [
-    'numTotalTests',
-    'numPassedTests',
-    'numFailedTests',
-    'numPendingTests',
-    'numTodoTests',
-  ] as const) {
+  for (const field of ['numTotalTests', 'numFailedTests'] as const) {
     assert.throws(
       () => parseJestJson(JSON.stringify({ ...complete, [field]: 99 })),
       new RegExp(`${field} is 99, but assertionResults contain`),
     );
+  }
+  for (const field of ['numPassedTests', 'numPendingTests', 'numTodoTests'] as const) {
+    assert.equal(parseJestJson(JSON.stringify({ ...complete, [field]: 99 })).tests.length, 4);
   }
   assert.throws(
     () => parseJestJson(JSON.stringify({ ...complete, numTotalTests: -1 })),
@@ -211,6 +208,25 @@ test('Jest-compatible JSON validates its reported assertion totals', () => {
     () => parseJestJson(JSON.stringify({ ...complete, numTotalTests: 1.5 })),
     /numTotalTests must be a non-negative safe integer/,
   );
+});
+
+test('Jest-compatible JSON keeps a bailed Vitest run whose pending tests are uncounted', () => {
+  const bailed = JSON.stringify({
+    numTotalTests: 3,
+    numPassedTests: 1,
+    numFailedTests: 1,
+    numPendingTests: 0,
+    numTodoTests: 0,
+    testResults: [{
+      name: '/repo/test/bail.test.js',
+      assertionResults: [
+        { title: 'a passes', status: 'passed' },
+        { title: 'b fails', status: 'failed', failureMessages: ['expected 1 to be 2'] },
+        { title: 'c never ran', status: 'pending' },
+      ],
+    }],
+  });
+  assert.deepEqual(parseJestJson(bailed).tests.map(item => item.status), ['passed', 'failed', 'skipped']);
 });
 
 test('Jest retry counts map a passing test with empty failure messages to noFlakyTests', () => {

--- a/tests/adapters/testing.test.ts
+++ b/tests/adapters/testing.test.ts
@@ -180,6 +180,39 @@ test('Jest-compatible retry evidence maps an ultimately passing test to noFlakyT
   assert.equal(testRunBreaches(parseJestJson(jestSample), { noFlakyTests }).length, 0);
 });
 
+test('Jest-compatible JSON validates its reported assertion totals', () => {
+  const complete = {
+    ...JSON.parse(jestSample),
+    numTotalTests: 4,
+    numPassedTests: 1,
+    numFailedTests: 1,
+    numPendingTests: 1,
+    numTodoTests: 1,
+  };
+  assert.equal(parseJestJson(JSON.stringify(complete)).tests.length, 4);
+
+  for (const field of [
+    'numTotalTests',
+    'numPassedTests',
+    'numFailedTests',
+    'numPendingTests',
+    'numTodoTests',
+  ] as const) {
+    assert.throws(
+      () => parseJestJson(JSON.stringify({ ...complete, [field]: 99 })),
+      new RegExp(`${field} is 99, but assertionResults contain`),
+    );
+  }
+  assert.throws(
+    () => parseJestJson(JSON.stringify({ ...complete, numTotalTests: -1 })),
+    /numTotalTests must be a non-negative safe integer/,
+  );
+  assert.throws(
+    () => parseJestJson(JSON.stringify({ ...complete, numTotalTests: 1.5 })),
+    /numTotalTests must be a non-negative safe integer/,
+  );
+});
+
 test('Jest retry counts map a passing test with empty failure messages to noFlakyTests', () => {
   const noFlakyTests = defineRule({
     id: 'testing/no-flaky-tests',
@@ -297,6 +330,35 @@ test('testing adapter refuses when a command completes without a readable report
     if (result.verdict !== 'refuse') return;
     assert.equal(result.why.code, 'test-report-unavailable');
     assert.match(result.why.detail ?? '', /configuration failed/);
+  });
+});
+
+test('testing adapter refuses a report whose summary contradicts its assertions', async () => {
+  await withWorkspace(async root => {
+    const contradictory = JSON.stringify({
+      success: true,
+      numTotalTests: 1,
+      numPassedTests: 1,
+      testResults: [],
+    });
+    const runner: TestRunner = {
+      description: 'write contradictory Jest JSON',
+      async run(ctx) {
+        await writeFile(ctx.reportFile, contradictory, 'utf8');
+        return { kind: 'completed', exitCode: 0, stdout: '', stderr: '' };
+      },
+    };
+    const adapter = testing({
+      runner,
+      report: report.jestJson(),
+      rules: { testsPass: true },
+    });
+
+    const result = await adapter.check.run({ root, rules: [adapter.rules.testsPass.id] });
+    assert.equal(result.verdict, 'refuse');
+    if (result.verdict !== 'refuse') return;
+    assert.equal(result.why.code, 'test-report-unavailable');
+    assert.match(result.why.detail ?? '', /numTotalTests is 1, but assertionResults contain 0/);
   });
 });
 


### PR DESCRIPTION
## Problem

On `main`, `{ numTotalTests: 1, numPassedTests: 1, testResults: [] }` produced a zero-test PASS. A report whose own totals contradict its assertions cannot support a trustworthy verdict.

## Fix

`parseJestJson` reads the five aggregate counts. Each present count must be a non-negative safe integer. `numTotalTests` and `numFailedTests` must also equal the counts derived from `assertionResults`. A mismatch throws, and the adapter turns it into the existing `test-report-unavailable` REFUSE.

Only those two counts are compared. Vitest 1.x and 2.0.x count a skipped or todo test as passed. Every Vitest version, 5.0.0 included, leaves tests that never ran under `bail` out of `numPendingTests`. Comparing all five refused those genuine reports.

## Verification

- `npm run check`: 231/231 native tests, 4/4 self-Gates, 22/22 Rules, all proofs
- Red-proof: with `main`'s parser planted, the contradiction tests fail (2); with the five-count parser planted, the bail test and the tolerance asserts fail (2); restored, 28/28
- Real reports: 13 accepted (Vitest 1.6.1, 2.0.0, 2.1.9, 3.2.7, 4.1.11, 5.0.0 with skip, todo, bail, merge-reports; Jest 30.5.0), 3 corrupt shapes refused
