### PR TITLE
Reject invalid configured Vitest report paths

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -69,6 +69,7 @@ Vitest config. Keep the Vitest `root` at `cwd`. If the two disagree, the Check
 refuses because the report is not found. A keyed `outputFile` works when
 `reportFile` matches its `json` entry. When `reportFile` is absent, Redproof
 continues to direct Vitest to a private temporary JSON report.
+Empty or absolute `reportFile` values are rejected before Vitest starts.
 
 Redproof passes `--no-cache` to Vitest. Without it, Vitest writes a results
 cache under `node_modules/.vite` inside the project, and a proof run refuses

--- a/packages/testing/src/core/paths.ts
+++ b/packages/testing/src/core/paths.ts
@@ -4,6 +4,12 @@ export type ResolvedTestingPath =
   | { readonly kind: 'inside'; readonly path: string }
   | { readonly kind: 'outside'; readonly path: string };
 
+/** Reject a path option whose contract requires a non-empty relative value. */
+export function validateRelativeTestingPath(name: string, path: string): void {
+  if (!path.trim()) throw new Error(`${name} must not be empty.`);
+  if (isAbsolute(path)) throw new Error(`${name} must be relative.`);
+}
+
 /** Both paths must be absolute. */
 function isInsideRoot(root: string, candidate: string): boolean {
   const rel = relative(root, candidate);

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -255,7 +255,7 @@ export function vitest<const O extends TestRuleOptions>(
       'run',
       '--reporter=json',
       '--no-cache',
-      ...(options.reportFile ? [] : [`--outputFile=${reportFile}`]),
+      ...(options.reportFile !== undefined ? [] : [`--outputFile=${reportFile}`]),
       ...(options.configFile ? ['--config', options.configFile] : []),
       ...(options.args ?? []),
       ...(options.files ?? []),
@@ -263,7 +263,7 @@ export function vitest<const O extends TestRuleOptions>(
   });
 
   return testing({
-    runner: options.reportFile
+    runner: options.reportFile !== undefined
       ? configuredVitestReport(runner, { cwd, reportFile: options.reportFile })
       : runner,
     report: jestJson(),

--- a/packages/testing/src/shell/vitest-runner.ts
+++ b/packages/testing/src/shell/vitest-runner.ts
@@ -2,7 +2,11 @@ import { randomUUID } from 'node:crypto';
 import { copyFile, lstat, realpath, rename, rm } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
 import type { TestRunner, TestRunnerCompleted, TestRunnerResult } from '../model.ts';
-import { confineCanonicalTestingPath, resolveTestingPath } from '../core/paths.ts';
+import {
+  confineCanonicalTestingPath,
+  resolveTestingPath,
+  validateRelativeTestingPath,
+} from '../core/paths.ts';
 
 export type ConfiguredVitestReportOptions = {
   readonly cwd: string;
@@ -53,6 +57,8 @@ export function configuredVitestReport(
   runner: TestRunner,
   options: ConfiguredVitestReportOptions,
 ): TestRunner {
+  validateRelativeTestingPath('reportFile', options.reportFile);
+
   return {
     ...runner,
 

--- a/tests/adapters/testing.test.ts
+++ b/tests/adapters/testing.test.ts
@@ -3,7 +3,7 @@ import { chmod, mkdir, readdir, readFile, realpath, rm, symlink, writeFile } fro
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
-import { testing, report, runner, parseJestJson, parseJunitXml, testRunBreaches, type TestRunner } from '@redproof/testing';
+import { testing, report, runner, parseJestJson, parseJunitXml, testRunBreaches, vitest, type TestRunner } from '@redproof/testing';
 import { defineRule } from 'redproof';
 import { configuredVitestReport } from '../../packages/testing/src/shell/vitest-runner.ts';
 import { withWorkspace } from '../helpers/workspace.ts';
@@ -560,4 +560,15 @@ test('a configured Vitest report refuses paths outside the Gate root', async () 
     assert.equal(symbolicResult.kind, 'unavailable');
     assert.equal(ran, false);
   });
+});
+
+test('the Vitest adapter rejects invalid configured report paths before execution', () => {
+  assert.throws(
+    () => vitest({ reportFile: '', rules: { testsPass: true } }),
+    /reportFile must not be empty/,
+  );
+  assert.throws(
+    () => vitest({ reportFile: join(tmpdir(), 'results.json'), rules: { testsPass: true } }),
+    /reportFile must be relative/,
+  );
 });


### PR DESCRIPTION
Written by an AI agent on behalf of @schalermthai; it has not yet been reviewed by a human.

## Summary
- reject empty and absolute `reportFile` values during adapter construction
- use an explicit `undefined` check so empty input cannot silently fall back to Redproof’s private output path
- keep validation in the testing functional core and cover the public Vitest adapter

## Why
`reportFile` is documented as cwd-relative. Node’s `path.join("project", "/tmp/results.json")` yields `project/tmp/results.json`, so Redproof protected and searched an in-Gate path while Vitest could follow its config and write the absolute path outside the Gate. The adapter should stop before launching Vitest when its lifecycle contract cannot be honored.

## Verification
- `npm run check` (229/229 native tests, 4/4 self-Gates, 22/22 Rules, all self-proofs)
- `npm run verify:package`
- clean Vitest fixture and all six proofs
- focused adapter tests: 26/26