### PR TITLE
Support missing Vitest report directories

### DIFF
--- a/docs/built-in-adapters.md
+++ b/docs/built-in-adapters.md
@@ -70,6 +70,9 @@ refuses because the report is not found. A keyed `outputFile` works when
 `reportFile` matches its `json` entry. When `reportFile` is absent, Redproof
 continues to direct Vitest to a private temporary JSON report.
 Empty or absolute `reportFile` values are rejected before Vitest starts.
+The report's parent directory may be absent before the run when Vitest creates
+it while writing the report. Redproof removes newly created report directories
+afterward when they remain empty.
 
 Redproof passes `--no-cache` to Vitest. Without it, Vitest writes a results
 cache under `node_modules/.vite` inside the project, and a proof run refuses

--- a/fixtures/testing-vitest/gates/tests.ts
+++ b/fixtures/testing-vitest/gates/tests.ts
@@ -4,7 +4,7 @@ import { defineGate, defineProofs, locate, mutate, proof } from 'redproof';
 const adapter = vitest({
   cwd: 'project',
   configFile: 'vitest.config.js',
-  reportFile: 'results.json',
+  reportFile: 'reports/results.json',
   rules: {
     testsPass: true,
     noFlakyTests: true,

--- a/fixtures/testing-vitest/project/global-setup.js
+++ b/fixtures/testing-vitest/project/global-setup.js
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 
 export async function teardown() {
-  const report = JSON.parse(await readFile('results.json', 'utf8'));
+  const report = JSON.parse(await readFile('reports/results.json', 'utf8'));
   assert.equal(typeof report.success, 'boolean');
   assert.ok(report.numTotalTests >= 1);
 }

--- a/fixtures/testing-vitest/project/results.json
+++ b/fixtures/testing-vitest/project/results.json
@@ -1,1 +1,0 @@
-{"sentinel":true}

--- a/fixtures/testing-vitest/project/vitest.config.js
+++ b/fixtures/testing-vitest/project/vitest.config.js
@@ -3,6 +3,6 @@ export default {
     include: ['test/**/*.test.js'],
     globalSetup: './global-setup.js',
     reporters: ['json'],
-    outputFile: 'results.json',
+    outputFile: 'reports/results.json',
   },
 };

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -38,9 +38,9 @@ export default defineGate({ id: 'unit-tests', adapter });
 `outputFile` already configured by Vitest, allowing project setup or teardown
 to inspect the same fresh report. It is relative to `cwd` and must name the
 same file as the config `outputFile`. Redproof restores any pre-existing report
-afterward. Its parent directory may be absent when Vitest creates it during the
-run; Redproof removes newly created report directories that remain empty. Omit
-`reportFile` to use Redproof's private temporary report.
+afterward. The report's parent directory may be absent when Vitest creates it
+during the run; Redproof removes newly created report directories that remain
+empty. Omit `reportFile` to use Redproof's private temporary report.
 
 `noFlakyTests` is available for Jest-compatible JSON reports. It breaches when
 a test passes only after a retry. Vitest keeps the earlier failure messages in

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -38,7 +38,9 @@ export default defineGate({ id: 'unit-tests', adapter });
 `outputFile` already configured by Vitest, allowing project setup or teardown
 to inspect the same fresh report. It is relative to `cwd` and must name the
 same file as the config `outputFile`. Redproof restores any pre-existing report
-afterward. Omit `reportFile` to use Redproof's private temporary report.
+afterward. Its parent directory may be absent when Vitest creates it during the
+run; Redproof removes newly created report directories that remain empty. Omit
+`reportFile` to use Redproof's private temporary report.
 
 `noFlakyTests` is available for Jest-compatible JSON reports. It breaches when
 a test passes only after a retry. Vitest keeps the earlier failure messages in

--- a/packages/testing/src/shell/vitest-runner.ts
+++ b/packages/testing/src/shell/vitest-runner.ts
@@ -1,7 +1,12 @@
 import { randomUUID } from 'node:crypto';
-import { copyFile, lstat, realpath, rename, rm } from 'node:fs/promises';
+import { copyFile, lstat, realpath, rename, rm, rmdir } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
-import type { TestRunner, TestRunnerCompleted, TestRunnerResult } from '../model.ts';
+import type {
+  TestRunner,
+  TestRunnerCompleted,
+  TestRunnerResult,
+  TestRunnerUnavailable,
+} from '../model.ts';
 import {
   confineCanonicalTestingPath,
   resolveTestingPath,
@@ -13,7 +18,7 @@ export type ConfiguredVitestReportOptions = {
   readonly reportFile: string;
 };
 
-function unavailable(message: string, detail: string): TestRunnerResult {
+function unavailable(message: string, detail: string): TestRunnerUnavailable {
   return { kind: 'unavailable', message, detail };
 }
 
@@ -21,12 +26,84 @@ function detailOf(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+type PreparedReportPath = {
+  readonly kind: 'prepared';
+  readonly reportFile: string;
+  /** Canonical directories that did not exist before the run, shallowest first. */
+  readonly missingDirectories: readonly string[];
+};
+
+function isMissing(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && (error as NodeJS.ErrnoException).code === 'ENOENT';
+}
+
+/** Resolve through the nearest existing ancestor without creating tool-owned directories. */
+async function prepareReportPath(
+  canonicalRoot: string,
+  lexicalReport: string,
+): Promise<PreparedReportPath | TestRunnerUnavailable> {
+  let existingParent = dirname(lexicalReport);
+  const missingNames: string[] = [];
+
+  for (;;) {
+    const existing = await lstat(existingParent).catch((error: Error) => error);
+    if (!(existing instanceof Error)) break;
+    if (!isMissing(existing)) {
+      return unavailable('The configured Vitest report directory could not be inspected.', existing.message);
+    }
+
+    const parent = dirname(existingParent);
+    if (parent === existingParent) {
+      return unavailable('The configured Vitest report directory could not be resolved.', existing.message);
+    }
+    missingNames.unshift(basename(existingParent));
+    existingParent = parent;
+  }
+
+  const canonicalParent = await realpath(existingParent).catch((error: Error) => error);
+  if (canonicalParent instanceof Error) {
+    return unavailable('The configured Vitest report directory could not be resolved.', canonicalParent.message);
+  }
+  const confinedParent = confineCanonicalTestingPath(canonicalRoot, canonicalParent);
+  if (confinedParent.kind === 'outside') {
+    return unavailable('The configured Vitest report resolves outside the Gate root.', lexicalReport);
+  }
+
+  let reportParent = confinedParent.path;
+  const missingDirectories = missingNames.map(name => {
+    reportParent = join(reportParent, name);
+    return reportParent;
+  });
+  return {
+    kind: 'prepared',
+    reportFile: join(reportParent, basename(lexicalReport)),
+    missingDirectories,
+  };
+}
+
+async function removeEmptyDirectories(
+  directories: readonly string[],
+): Promise<TestRunnerResult | null> {
+  for (const directory of [...directories].reverse()) {
+    const removed = await rmdir(directory).catch((error: NodeJS.ErrnoException) => error);
+    if (!(removed instanceof Error) || removed.code === 'ENOENT') continue;
+    if (removed.code === 'ENOTEMPTY' || removed.code === 'EEXIST') break;
+    return unavailable('A generated Vitest report directory could not be removed.', removed.message);
+  }
+  return null;
+}
+
 /** Remove the fresh report and put the previous one back. Null when both succeed. */
-async function restoreReport(reportFile: string, backup: string | null): Promise<TestRunnerResult | null> {
+async function restoreReport(
+  reportFile: string,
+  backup: string | null,
+  missingDirectories: readonly string[],
+): Promise<TestRunnerResult | null> {
   const removed = await rm(reportFile, { force: true }).catch((error: Error) => error);
   const restored = backup === null
     ? null
     : await rename(backup, reportFile).catch((error: Error) => error);
+  const directoriesRemoved = await removeEmptyDirectories(missingDirectories);
   if (restored instanceof Error) {
     return unavailable(
       `The previous Vitest report could not be restored from ${backup}.`,
@@ -36,7 +113,7 @@ async function restoreReport(reportFile: string, backup: string | null): Promise
   if (removed instanceof Error) {
     return unavailable('The fresh Vitest report could not be removed after the run.', removed.message);
   }
-  return null;
+  return directoriesRemoved;
 }
 
 async function copyReport(
@@ -73,24 +150,13 @@ export function configuredVitestReport(
       }
 
       const canonicalRoot = await realpath(ctx.root).catch((error: Error) => error);
-      const canonicalParent = await realpath(dirname(lexicalReport.path)).catch((error: Error) => error);
-      if (canonicalRoot instanceof Error || canonicalParent instanceof Error) {
-        const detail = canonicalRoot instanceof Error
-          ? canonicalRoot.message
-          : canonicalParent instanceof Error
-            ? canonicalParent.message
-            : 'Unknown report-directory error.';
-        return unavailable('The configured Vitest report directory could not be resolved.', detail);
+      if (canonicalRoot instanceof Error) {
+        return unavailable('The configured Vitest report directory could not be resolved.', canonicalRoot.message);
       }
-      const confinedParent = confineCanonicalTestingPath(canonicalRoot, canonicalParent);
-      if (confinedParent.kind === 'outside') {
-        return unavailable(
-          'The configured Vitest report resolves outside the Gate root.',
-          lexicalReport.path,
-        );
-      }
+      const prepared = await prepareReportPath(canonicalRoot, lexicalReport.path);
+      if (prepared.kind === 'unavailable') return prepared;
 
-      const reportFile = join(confinedParent.path, basename(lexicalReport.path));
+      const { reportFile, missingDirectories } = prepared;
       const existing = await lstat(reportFile).catch((error: NodeJS.ErrnoException) => error);
       if (existing instanceof Error && existing.code !== 'ENOENT') {
         return unavailable('The configured Vitest report could not be inspected.', existing.message);
@@ -119,7 +185,7 @@ export function configuredVitestReport(
         outcome = unavailable('The test command failed before Vitest reported.', detailOf(error));
       }
 
-      return await restoreReport(reportFile, backup) ?? outcome;
+      return await restoreReport(reportFile, backup, missingDirectories) ?? outcome;
     },
   };
 }

--- a/tests/adapters/integration.test.ts
+++ b/tests/adapters/integration.test.ts
@@ -6,6 +6,9 @@ import { checkProject, proofEstablished, proveProject } from 'redproof';
 
 const configOf = (name: string) => resolve(`fixtures/${name}/redproof.config.ts`);
 
+/** A fixture precondition: the Vitest fixture runs in copies mode, so a committed
+ * `reports/` directory would stop it from exercising the missing-directory path.
+ * Cleanup itself is proven end to end by the workspace check after each proof. */
 async function assertMissing(path: string): Promise<void> {
   const entry = await lstat(path).catch((error: NodeJS.ErrnoException) => error);
   assert.equal(entry instanceof Error && entry.code, 'ENOENT');

--- a/tests/adapters/integration.test.ts
+++ b/tests/adapters/integration.test.ts
@@ -1,10 +1,15 @@
 import assert from 'node:assert/strict';
-import { readFile } from 'node:fs/promises';
+import { lstat } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import test from 'node:test';
 import { checkProject, proofEstablished, proveProject } from 'redproof';
 
 const configOf = (name: string) => resolve(`fixtures/${name}/redproof.config.ts`);
+
+async function assertMissing(path: string): Promise<void> {
+  const entry = await lstat(path).catch((error: NodeJS.ErrnoException) => error);
+  assert.equal(entry instanceof Error && entry.code, 'ENOENT');
+}
 
 test('dependency-cruiser adapter passes clean architecture and proves both mapped rules plus refusal', async () => {
   const check = await checkProject(configOf('dependency-cruiser-project'));
@@ -28,13 +33,13 @@ test('dependency-cruiser adapter passes clean architecture and proves both mappe
   );
 });
 
-test('Vitest adapter preserves a nested project report while proving test policies', async () => {
+test('Vitest adapter cleans a nested project report while proving test policies', async () => {
   const config = configOf('testing-vitest');
-  const sentinel = resolve('fixtures/testing-vitest/project/results.json');
+  const reports = resolve('fixtures/testing-vitest/project/reports');
   const check = await checkProject(config);
   assert.equal(check.exitCode, 0);
   assert.equal(check.results[0]?.result.verdict, 'pass');
-  assert.equal(await readFile(sentinel, 'utf8'), '{"sentinel":true}\n');
+  await assertMissing(reports);
 
   const proof = await proveProject(config);
   assert.equal(proof.exitCode, 0);
@@ -53,7 +58,7 @@ test('Vitest adapter preserves a nested project report while proving test polici
       ['refuse', true, 'refuse'],
     ],
   );
-  assert.equal(await readFile(sentinel, 'utf8'), '{"sentinel":true}\n');
+  await assertMissing(reports);
 });
 
 test('Stryker adapter passes strong tests and proves strict, baseline, score, and refusal policies', async () => {

--- a/tests/adapters/testing.test.ts
+++ b/tests/adapters/testing.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
-import { chmod, mkdir, readdir, readFile, realpath, rm, symlink, writeFile } from 'node:fs/promises';
+import { chmod, lstat, mkdir, readdir, readFile, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import test from 'node:test';
 import { testing, report, runner, parseJestJson, parseJunitXml, testRunBreaches, vitest, type TestRunner } from '@redproof/testing';
 import { defineRule } from 'redproof';
@@ -503,6 +503,65 @@ test('a configured Vitest report is fresh for the run and the previous file is r
     assert.equal(result.kind, 'completed');
     assert.equal(await readFile(capturedReport, 'utf8'), jestSample);
     assert.equal(await readFile(configuredReport, 'utf8'), 'stale report');
+  });
+});
+
+test('a configured Vitest report may create missing parent directories', async () => {
+  await withWorkspace(async root => {
+    const project = join(root, 'project');
+    const configuredReport = join(project, 'reports', 'nested', 'results.json');
+    const capturedReport = join(root, 'captured.json');
+    await mkdir(project);
+
+    const fake: TestRunner = {
+      description: 'fake Vitest that creates its output directory',
+      async run() {
+        await mkdir(dirname(configuredReport), { recursive: true });
+        await writeFile(configuredReport, jestSample, 'utf8');
+        return { kind: 'completed', exitCode: 0, stdout: '', stderr: '' };
+      },
+    };
+    const wrapped = configuredVitestReport(fake, {
+      cwd: 'project',
+      reportFile: 'reports/nested/results.json',
+    });
+    const result = await wrapped.run({ root, reportFile: capturedReport });
+
+    assert.equal(result.kind, 'completed');
+    assert.equal(await readFile(capturedReport, 'utf8'), jestSample);
+    const generatedDirectory = await lstat(join(project, 'reports')).catch(
+      (error: NodeJS.ErrnoException) => error,
+    );
+    assert.equal(generatedDirectory instanceof Error && generatedDirectory.code, 'ENOENT');
+  });
+});
+
+test('configured report cleanup preserves parent directories that already existed', async () => {
+  await withWorkspace(async root => {
+    const reports = join(root, 'project', 'reports');
+    const configuredReport = join(reports, 'nested', 'results.json');
+    await mkdir(reports, { recursive: true });
+
+    const fake: TestRunner = {
+      description: 'fake Vitest that creates a nested output directory',
+      async run() {
+        await mkdir(dirname(configuredReport));
+        await writeFile(configuredReport, jestSample, 'utf8');
+        return { kind: 'completed', exitCode: 0, stdout: '', stderr: '' };
+      },
+    };
+    const wrapped = configuredVitestReport(fake, {
+      cwd: 'project',
+      reportFile: 'reports/nested/results.json',
+    });
+    const result = await wrapped.run({ root, reportFile: join(root, 'captured.json') });
+
+    assert.equal(result.kind, 'completed');
+    assert.equal((await lstat(reports)).isDirectory(), true);
+    const generatedDirectory = await lstat(join(reports, 'nested')).catch(
+      (error: NodeJS.ErrnoException) => error,
+    );
+    assert.equal(generatedDirectory instanceof Error && generatedDirectory.code, 'ENOENT');
   });
 });
 

--- a/tests/adapters/testing.test.ts
+++ b/tests/adapters/testing.test.ts
@@ -565,6 +565,86 @@ test('configured report cleanup preserves parent directories that already existe
   });
 });
 
+test('configured report cleanup keeps a generated directory that gained other content', async () => {
+  await withWorkspace(async root => {
+    const project = join(root, 'project');
+    const reports = join(project, 'reports');
+    const configuredReport = join(reports, 'nested', 'results.json');
+    await mkdir(project);
+
+    const fake: TestRunner = {
+      description: 'fake Vitest whose project also writes coverage into the new directory',
+      async run() {
+        await mkdir(dirname(configuredReport), { recursive: true });
+        await writeFile(configuredReport, jestSample, 'utf8');
+        await writeFile(join(reports, 'coverage.txt'), 'user data', 'utf8');
+        return { kind: 'completed', exitCode: 0, stdout: '', stderr: '' };
+      },
+    };
+    const wrapped = configuredVitestReport(fake, {
+      cwd: 'project',
+      reportFile: 'reports/nested/results.json',
+    });
+    const result = await wrapped.run({ root, reportFile: join(root, 'captured.json') });
+
+    assert.equal(result.kind, 'completed');
+    assert.deepEqual(await readdir(reports), ['coverage.txt']);
+    assert.equal(await readFile(join(reports, 'coverage.txt'), 'utf8'), 'user data');
+  });
+});
+
+test('configured report cleanup refuses when a generated directory cannot be removed', async () => {
+  await withWorkspace(async root => {
+    const project = join(root, 'project');
+    const reports = join(project, 'reports');
+    const elsewhere = join(project, 'elsewhere');
+    await mkdir(reports, { recursive: true });
+    await mkdir(elsewhere);
+
+    const fake: TestRunner = {
+      description: 'fake Vitest that creates the new directory as a symbolic link',
+      async run() {
+        await symlink(elsewhere, join(reports, 'nested'));
+        await writeFile(join(elsewhere, 'results.json'), jestSample, 'utf8');
+        return { kind: 'completed', exitCode: 0, stdout: '', stderr: '' };
+      },
+    };
+    const wrapped = configuredVitestReport(fake, {
+      cwd: 'project',
+      reportFile: 'reports/nested/results.json',
+    });
+    const result = await wrapped.run({ root, reportFile: join(root, 'captured.json') });
+
+    assert.equal(result.kind, 'unavailable');
+    if (result.kind === 'unavailable') {
+      assert.equal(result.message, 'A generated Vitest report directory could not be removed.');
+    }
+  });
+});
+
+test('a configured Vitest report that never appears refuses for the report, not the cleanup', async () => {
+  await withWorkspace(async root => {
+    await mkdir(join(root, 'project'));
+
+    const fake: TestRunner = {
+      description: 'fake Vitest that writes nothing',
+      async run() {
+        return { kind: 'completed', exitCode: 0, stdout: '', stderr: '' };
+      },
+    };
+    const wrapped = configuredVitestReport(fake, {
+      cwd: 'project',
+      reportFile: 'reports/nested/results.json',
+    });
+    const result = await wrapped.run({ root, reportFile: join(root, 'captured.json') });
+
+    assert.equal(result.kind, 'unavailable');
+    if (result.kind === 'unavailable') {
+      assert.equal(result.message, 'Vitest did not produce its configured JSON report.');
+    }
+  });
+});
+
 test('a configured Vitest report refuses a stale file when the run writes nothing', async () => {
   await withWorkspace(async root => {
     const project = join(root, 'project');


### PR DESCRIPTION
## Summary

- allow a configured Vitest JSON report beneath parent directories that do not exist before the run
- confine the path through its nearest existing canonical ancestor
- remove only newly created report directories that remain empty
- exercise the lifecycle with the real nested Vitest fixture; the fixture runs in copies mode, so `prove` and its workspace check are what verify the cleanup end to end
- pin the cleanup branches with unit tests: a generated directory that gained other content is kept, a directory that cannot be removed refuses, and a report that never appears refuses for the report rather than the cleanup

## Verification

- npm run check
- npm run verify:package
- 237 native tests, 4 self-Gates, 22 Rules, all self-proofs, and all 6 Vitest fixture proofs pass

Written by an AI agent on behalf of @schalermthai; it has not yet been reviewed by a human.
