### PR TITLE
Add a custom adapter guide and keep each doc to one subject

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,9 @@ Completed failure exits breach the selected Rule. Missing executables, timeouts,
 See **[Command Checks](https://github.com/schalermthai/redproof/blob/main/docs/commands.md)** for exit-code policy,
 command groups, and what a Check reports about itself.
 
-See **[Composing Redproof](https://github.com/schalermthai/redproof/blob/main/docs/composition.md)** to create your own Gates, Rules, Checks, Proofs, Mutations, and Adapters.
+See **[Composing Redproof](https://github.com/schalermthai/redproof/blob/main/docs/composition.md)** to create your own Gates, Rules, Checks, Proofs, and Mutations.
+
+See **[Building an Adapter](https://github.com/schalermthai/redproof/blob/main/docs/building-an-adapter.md)** when a tool brings its own policy model, and for the guidelines that keep an Adapter's verdicts honest.
 
 For execution isolation, machine-readable reports, VS Code, and other workflows, see **[Tutorials](https://github.com/schalermthai/redproof/blob/main/docs/tutorials/README.md)**.
 
@@ -356,6 +358,7 @@ npm run redproof:describe -- gates/no-todo.ts
 - **[Built-in integrations](https://github.com/schalermthai/redproof/blob/main/docs/adapters.md)**
 - **[Command Checks](https://github.com/schalermthai/redproof/blob/main/docs/commands.md)**
 - **[Composing Redproof](https://github.com/schalermthai/redproof/blob/main/docs/composition.md)**
+- **[Building an Adapter](https://github.com/schalermthai/redproof/blob/main/docs/building-an-adapter.md)**
 - **[Tutorials](https://github.com/schalermthai/redproof/blob/main/docs/tutorials/README.md)**
 - **[Legacy modernization](https://github.com/schalermthai/redproof/blob/main/docs/legacy-modernization.md)**
 - **[Self-hosting Redproof](https://github.com/schalermthai/redproof/blob/main/docs/self-hosting.md)**

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -127,14 +127,8 @@ report.jestJson()
 report.junitXml()
 ```
 
-For a custom test system, implement only the runner or report normalization layer:
-
-```ts fragment
-defineTestRunner(...)
-defineTestReport(...)
-```
-
-Create a new full Adapter only when a tool introduces a genuinely different policy model.
+For a custom test system, implement only the runner or the report format. See
+**[Extend the testing adapter instead](building-an-adapter.md#extend-the-testing-adapter-instead)**.
 
 ### What a command runner reports about itself
 
@@ -312,15 +306,8 @@ refuses; remove it from the baseline.
 
 For a useful RED proof, weaken the test suite and confirm Stryker notices the loss of test strength.
 
-## Choosing between an Adapter and a parser
+## Next
 
-A useful rule of thumb:
-
-> Create a new Adapter when the external system introduces a new policy model.
-
-> Create a runner or parser when it only introduces a new invocation method or data format.
-
-When the tool is simply an executable, a Check is enough. See **[Command
-Checks](commands.md)**.
-
-For writing your own integration, continue with **[Composing Redproof](composition.md#creating-an-adapter)**.
+- **[Building an Adapter](building-an-adapter.md)** when no built-in integration fits, and for
+  choosing between a Check, a runner or report format, and an Adapter.
+- **[Command Checks](commands.md)** when the tool is an executable and its exit code is the result.

--- a/docs/building-an-adapter.md
+++ b/docs/building-an-adapter.md
@@ -1,0 +1,322 @@
+# Building an Adapter
+
+An Adapter translates an external tool into Redproof Rules and one Check. The
+tool keeps doing the real analysis. The Adapter decides what its output means.
+
+This page shows how to build one, and the rules that keep its verdicts honest.
+The `@redproof/testing` package follows every rule here, so its source is the
+worked example.
+
+- [Decide what to build](#decide-what-to-build)
+- [Three lanes for a wrong answer](#three-lanes-for-a-wrong-answer)
+- [The shape of an Adapter](#the-shape-of-an-adapter)
+- [Guidelines](#guidelines)
+- [Extend the testing adapter instead](#extend-the-testing-adapter-instead)
+- [Prove it](#prove-it)
+
+## Decide what to build
+
+Three pieces can wrap a tool. Pick the smallest one that fits.
+
+> Create a Check when the tool is an executable and its exit code is the result.
+
+> Create a runner or a report format when the tool only changes how a test
+> suite starts, or how its results are written.
+
+> Create an Adapter when the tool brings its own policy model, such as a rule
+> catalogue or a score.
+
+For the first case, `redproof/command` builds the Check for you. See
+**[Command Checks](commands.md)**. For the second case, see
+[Extend the testing adapter instead](#extend-the-testing-adapter-instead).
+
+## Three lanes for a wrong answer
+
+A Check returns PASS, FAIL, or REFUSE. An Adapter adds one lane before them: a
+bad option throws when the Gate module loads. No Check exists yet, so no verdict
+exists yet.
+
+| Lane | When | Mechanism |
+|---|---|---|
+| Load-time error | The option alone proves the Gate is wrong | `throw` in the Adapter factory |
+| REFUSE | The run happened, but the evidence cannot be trusted | `result.refuse` with a Diagnostic |
+| FAIL | The report proves a Rule broken | `result.fromBreaches` with Breaches |
+
+Sort every failure into one lane. The guidelines below say how.
+
+## The shape of an Adapter
+
+This example compiles. It runs an imaginary tool and interprets its findings.
+
+```ts
+import { breach, counting, defineAdapter, defineRules, result } from 'redproof';
+
+type Finding = {
+  readonly code: string;
+  readonly message: string;
+  readonly file: string;
+  readonly line: number;
+};
+
+type ToolRun =
+  | { readonly kind: 'completed'; readonly exitCode: number; readonly findings: readonly Finding[] }
+  | { readonly kind: 'unavailable'; readonly message: string; readonly detail?: string };
+
+declare function runMyTool(root: string, configFile: string): Promise<ToolRun>;
+
+export function myTool(options: { readonly configFile: string }) {
+  if (!options.configFile.trim()) {
+    throw new Error('myTool requires a configFile.');
+  }
+
+  const rules = defineRules({
+    policy: {
+      id: 'my-tool/policy',
+      description: 'The external policy must hold.',
+    },
+  });
+
+  return defineAdapter({
+    kind: 'my-tool',
+    rules,
+
+    check: {
+      description: 'run my tool and interpret its structured findings',
+      counting: counting.supported,
+
+      async run(ctx) {
+        const startedAt = new Date().toISOString();
+        const scan = (inspected: number | null) => ({
+          source: 'my-tool',
+          startedAt,
+          finishedAt: new Date().toISOString(),
+          inspected,
+        });
+
+        const run = await runMyTool(ctx.root, options.configFile);
+
+        if (run.kind === 'unavailable') {
+          return result.refuse(scan(null), {
+            code: 'my-tool-unavailable',
+            message: run.message,
+            location: null,
+            ...(run.detail ? { detail: run.detail } : {}),
+          });
+        }
+
+        if (run.exitCode !== 0 && run.findings.length === 0) {
+          return result.refuse(scan(null), {
+            code: 'my-tool-unsuccessful',
+            message: 'my tool exited unsuccessfully without structured findings.',
+            location: null,
+          });
+        }
+
+        return result.fromBreaches(
+          scan(run.findings.length),
+          run.findings.map(finding =>
+            breach(rules.policy, {
+              code: finding.code,
+              message: finding.message,
+              location: { file: finding.file, line: finding.line, column: null },
+            }),
+          ),
+        );
+      },
+    },
+  });
+}
+```
+
+The Adapter translates the tool into Redproof semantics:
+
+```text
+real policy violation     → Breach → FAIL
+cannot evaluate reliably  → Diagnostic → REFUSE
+bad option                → throw before any Check exists
+```
+
+## Guidelines
+
+### 1. Validate options in the constructor and throw
+
+Bad configuration is not a verdict. A REFUSE would say the run was tried. A
+throw says the Gate was never valid. Check every option that the option alone
+can prove wrong: an empty Rule set, an unknown key, an empty or absolute path.
+
+The testing adapter does this before it builds a Rule catalogue:
+
+```ts
+import type { TestRuleOptions } from '@redproof/testing';
+
+declare const options: { readonly rules: TestRuleOptions };
+
+if (
+  !options.rules.testsPass
+  && !options.rules.noFlakyTests
+  && !options.rules.noSkippedTests
+  && !options.rules.noTodoTests
+) {
+  throw new Error('Testing adapter requires at least one Redproof rule.');
+}
+```
+
+### 2. Give your runner a result union with an unavailable case
+
+Never throw from `run`. A throw inside a Check is not one of the three
+verdicts. Return `completed` when the tool ran, and `unavailable` when it could
+not. The Adapter maps `unavailable` to one REFUSE code.
+
+```ts
+import { defineTestRunner } from '@redproof/testing';
+
+declare function startInHouseTool(
+  reportFile: string,
+): Promise<{ exitCode: number; stdout: string; stderr: string }>;
+
+export const inHouseRunner = defineTestRunner({
+  description: 'run the in-house test tool',
+
+  async run(ctx) {
+    const started = await startInHouseTool(ctx.reportFile).catch((error: Error) => error);
+    if (started instanceof Error) {
+      return {
+        kind: 'unavailable',
+        message: 'The in-house test tool could not start.',
+        detail: started.message,
+      };
+    }
+    return { kind: 'completed', ...started };
+  },
+});
+```
+
+A wrapper that sets a report aside and restores it afterwards follows the same
+rule. A failed restore returns `unavailable` and replaces the run's outcome,
+because the project is no longer in its starting state.
+
+### 3. Keep the parser pure and let it throw on untrusted structure
+
+The parser turns text into a model. It has no filesystem and no process. When
+the structure cannot be trusted, throw. A missing list, an unknown status, or a
+total that contradicts the listed items are all throws.
+
+Map every parser throw to one REFUSE code in the shell. The testing adapter
+catches them in one place and returns `test-report-unavailable`:
+
+```text
+try {
+  run = normalizeRun(root, options.report.parse(await readFile(reportFile, 'utf8')));
+} catch (error) {
+  return result.refuse(scan, {
+    code: 'test-report-unavailable',
+    message: 'The test command did not produce a trustworthy structured report.',
+    location: null,
+    detail: error instanceof Error ? error.message : String(error),
+  });
+}
+```
+
+Compare only the totals that every producer agrees on. Vitest 1.x counts a
+skipped test as passed, and every Vitest version leaves tests that never ran
+under `bail` out of its pending count. The testing adapter therefore compares
+only the total and failed counts.
+
+### 4. Declare capabilities on the report format
+
+A report format states what it can see. A Rule that needs evidence the format
+does not carry is rejected when the Gate loads, not at run time.
+
+JUnit XML records only the final outcome, so it cannot show a retry:
+
+```ts
+import type { TestReportFormat, TestRuleOptions } from '@redproof/testing';
+
+declare const options: { readonly rules: TestRuleOptions; readonly report: TestReportFormat };
+
+if (options.rules.noFlakyTests && !options.report.capabilities.flaky) {
+  throw new Error(`Report format ${options.report.kind} cannot distinguish flaky tests.`);
+}
+```
+
+### 5. Emit a Breach only from structured evidence
+
+A Breach names one Rule and one location. Build it from the tool's structured
+output, never from its exit code alone. Keep the exit code as the last guard:
+a failing exit with zero structured failures is a REFUSE, because something
+went wrong that the report does not explain.
+
+```text
+if (execution.exitCode !== 0 && counts.failed === 0) {
+  return result.refuse(scan, {
+    code: 'test-runner-unsuccessful',
+    message: 'The test command exited unsuccessfully without structured failed tests explaining the exit.',
+    location: null,
+  });
+}
+```
+
+## Extend the testing adapter instead
+
+When your tool is a test runner, you do not need a new Adapter. The testing
+adapter composes a `TestRunner` and a `TestReportFormat`. Implement only the
+part that differs.
+
+```ts
+import { defineTestReport, defineTestRunner, testing, type TestCase } from '@redproof/testing';
+
+declare function startInHouseTool(
+  reportFile: string,
+): Promise<{ exitCode: number; stdout: string; stderr: string }>;
+declare function toTestCase(entry: unknown): TestCase;
+
+const inHouseRunner = defineTestRunner({
+  description: 'run the in-house test tool',
+  async run(ctx) {
+    const started = await startInHouseTool(ctx.reportFile).catch((error: Error) => error);
+    if (started instanceof Error) {
+      return { kind: 'unavailable', message: 'The in-house test tool could not start.', detail: started.message };
+    }
+    return { kind: 'completed', ...started };
+  },
+});
+
+const inHouseJson = defineTestReport({
+  kind: 'in-house-json',
+  extension: '.json',
+  capabilities: { todo: false },
+  parse(input) {
+    const parsed = JSON.parse(input) as { tests?: unknown };
+    if (!Array.isArray(parsed.tests)) {
+      throw new Error('In-house report is missing tests.');
+    }
+    return { tests: parsed.tests.map(toTestCase) };
+  },
+});
+
+export const adapter = testing({
+  runner: inHouseRunner,
+  report: inHouseJson,
+  rules: { testsPass: true, noSkippedTests: true },
+});
+```
+
+The built-in `runner.command` already confines `cwd` inside the Gate root and
+reports what it will run. Prefer it when the tool is a command line.
+
+## Prove it
+
+An Adapter is only as good as its proofs. Write one RED proof per Rule, one
+GREEN proof, and one REFUSE proof that removes the evidence the Check needs.
+The REFUSE proof is the one people skip. It is the one that shows the Adapter
+does not guess.
+
+See **[Proofs](composition.md#proofs)** for the API, and the
+[Vitest fixture Gate](../fixtures/testing-vitest/gates/tests.ts) for all three
+kinds against one Adapter.
+
+## Next
+
+- **[Composing Redproof](composition.md)** for Rules, Checks, Proofs, and Mutations.
+- **[Command Checks](commands.md)** for a guardrail that is already an executable.
+- **[Built-in integrations](adapters.md)** for the Adapters that ship with Redproof.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -4,8 +4,8 @@ A **Check** decides whether the Rules of a Gate hold. When a guardrail already
 exists as an executable, you do not need to write that Check by hand.
 
 `redproof/command` builds a Check from a command line. It is part of the Check
-layer, not an Adapter. Reach for an Adapter only when a tool brings its own
-policy model, such as a rule catalogue or a score.
+layer, not an Adapter. See **[Decide what to build](building-an-adapter.md#decide-what-to-build)**
+when you are not sure which one you need.
 
 - [One command](#one-command)
 - [Exit codes decide the verdict](#exit-codes-decide-the-verdict)
@@ -136,5 +136,7 @@ does. An explicit description always wins.
 
 - **[Composing Redproof](composition.md)** for Rules, Checks, Proofs, and
   Mutations.
-- **[Built-in integrations](adapters.md)** for tools that bring their own policy
-  model.
+- **[Building an Adapter](building-an-adapter.md)** for tools that bring their
+  own policy model.
+- **[Built-in integrations](adapters.md)** for the Adapters that ship with
+  Redproof.

--- a/docs/composition.md
+++ b/docs/composition.md
@@ -406,88 +406,24 @@ sequential and parallel execution, and what a Check reports about itself.
 
 ## Creating an Adapter
 
-Use an Adapter when an external system introduces its own policy model.
-
-```ts fragment
-import {
-  breach,
-  counting,
-  defineAdapter,
-  defineRules,
-  result,
-} from 'redproof';
-
-export function myTool() {
-  const rules = defineRules({
-    policy: {
-      id: 'my-tool/policy',
-      description: 'The external policy must hold.',
-    },
-  });
-
-  return defineAdapter({
-    kind: 'my-tool',
-    rules,
-
-    check: {
-      description: 'run my tool and interpret its structured findings',
-      counting: counting.supported,
-
-      async run(ctx) {
-        const startedAt = new Date().toISOString();
-
-        try {
-          const findings = await runMyTool(ctx.root);
-          const scan = {
-            source: 'my-tool',
-            startedAt,
-            finishedAt: new Date().toISOString(),
-            inspected: findings.length,
-          } as const;
-
-          return result.fromBreaches(
-            scan,
-            findings.map(finding =>
-              breach(rules.policy, {
-                code: finding.code,
-                message: finding.message,
-                location: finding.location,
-              }),
-            ),
-          );
-        } catch (error) {
-          return result.refuse(
-            {
-              source: 'my-tool',
-              startedAt,
-              finishedAt: new Date().toISOString(),
-              inspected: null,
-            },
-            {
-              code: 'my-tool-unavailable',
-              message: 'The external tool could not complete the check.',
-              location: null,
-              detail: error instanceof Error ? error.message : String(error),
-            },
-          );
-        }
-      },
-    },
-  });
-}
-```
-
-The Adapter should translate the external system into Redproof semantics:
+Use an Adapter when an external system introduces its own policy model. An
+Adapter binds a Rule catalogue to one Check with `defineAdapter`, and translates
+the external system into Redproof semantics:
 
 ```text
 real policy violation     → Breach → FAIL
 cannot evaluate reliably  → Diagnostic → REFUSE
+bad option                → throw before any Check exists
 ```
 
 Do not infer Redproof semantics from a process exit code when structured evidence can distinguish the two.
 
+See **[Building an Adapter](building-an-adapter.md)** for a complete example and
+the guidelines that keep its verdicts honest.
+
 ## Next
 
+- **[Building an Adapter](building-an-adapter.md)**
 - **[Built-in integrations](adapters.md)**
 - **[Execution isolation](tutorials/execution-isolation.md)**
 - **[Reporters](tutorials/reporters.md)**

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -26,4 +26,6 @@ Use the compact reporter with a problem matcher or open SARIF output with a SARI
 
 For a guardrail that is already an executable, see **[Command Checks](../commands.md)**.
 
-For authoring Rules, Checks, Proofs, Mutations, and Adapters, see **[Composing Redproof](../composition.md)**.
+For authoring Rules, Checks, Proofs, and Mutations, see **[Composing Redproof](../composition.md)**.
+
+For wrapping a tool that brings its own policy model, see **[Building an Adapter](../building-an-adapter.md)**.

--- a/gates/support/check-doc-fragment-budget.ts
+++ b/gates/support/check-doc-fragment-budget.ts
@@ -2,7 +2,7 @@ import { glob, readFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 
 const ROOT = resolve(import.meta.dirname, '../..');
-const MAX_FRAGMENTS = 39;
+const MAX_FRAGMENTS = 37;
 const FENCE = /^```(?:ts|typescript)([^\n]*)\n[\s\S]*?^```$/gm;
 
 let fragments = 0;


### PR DESCRIPTION
## Problem

The docs mixed subjects. `docs/built-in-adapters.md` ended with the decision guide between a Check, a runner or report format, and an Adapter. `docs/commands.md` repeated part of that guide in its intro. `docs/composition.md` held the only Adapter walkthrough, as an unchecked fragment with an undefined `runMyTool`. No page recorded the rules that keep an Adapter's verdicts honest, so the five lanes the testing adapter uses lived only in its source.

## Fix

Add `docs/custom-adapter.md`. It owns the decision guide, the three lanes for a wrong answer, a checked Adapter example, five guidelines drawn from the testing adapter, and how to extend the testing adapter with a custom runner or report format. Each guideline shows the real code, as a checked block or a text excerpt.

Trim the other docs to their own subject and link to the new page: `built-in-adapters.md` keeps only the built-ins, `commands.md` keeps only Command Checks, `composition.md` keeps the model and a short Adapter pointer. The README and the tutorials index link to the new page.

## Verification

- `npm run docs:typecheck`: 21 checked examples across 11 documents, all pass. Red-proof: a planted wrong type in the new page's first example reports four errors naming `docs/custom-adapter.md`; restored, green.
- Fragment budget: 37 of 39, down from 38.
- `npm run self:check` after `npm run build`: 4 of 4 Gates, 22 of 22 Rules, including `repository/docs-relative-links-resolve`.
- Fragment budget ratchet: the limit in `gates/support/check-doc-fragment-budget.ts` is lowered from 39 to 37 to match the new debt. The first CI run failed the self-proof `rejects growth in unchecked documentation fragments` because one planted fragment no longer crossed 39. `npm run self:prove -- gates/static-contracts.ts`: 4 of 4 proofs, including that one at expected=red actual=fail.
- Review round: `docs/adapters.md` is renamed to `docs/built-in-adapters.md`, and the guide to `docs/custom-adapter.md`. The guide now opens with the two simpler options, a native `run()` Check and a Command Check, before the Adapter case. `npm run docs:typecheck`: 23 checked examples. `npm run self:prove`: 27 of 27.
