### PR TITLE
Rename the adapter docs and lead the custom adapter guide with the simpler options

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,16 +245,16 @@ FAIL     one or more Rules were breached
 REFUSE   the Check could not decide safely
 ```
 
-## Built-in integrations
+## Built-in Adapters
 
 You do not need to build every Gate yourself.
 
-- **[`@redproof/testing`](https://github.com/schalermthai/redproof/blob/main/docs/adapters.md#testing)** — test suites, flaky tests, skipped tests, TODO tests; supports Jest-compatible JSON and JUnit XML
-- **[`@redproof/eslint`](https://github.com/schalermthai/redproof/blob/main/docs/adapters.md#eslint)** — selected ESLint rules as Redproof Rules
-- **[`@redproof/dependency-cruiser`](https://github.com/schalermthai/redproof/blob/main/docs/adapters.md#dependency-cruiser)** — architecture and dependency boundaries
-- **[`@redproof/stryker`](https://github.com/schalermthai/redproof/blob/main/docs/adapters.md#stryker)** — mutation detection and mutation-score policies
+- **[`@redproof/testing`](https://github.com/schalermthai/redproof/blob/main/docs/built-in-adapters.md#testing)** — test suites, flaky tests, skipped tests, TODO tests; supports Jest-compatible JSON and JUnit XML
+- **[`@redproof/eslint`](https://github.com/schalermthai/redproof/blob/main/docs/built-in-adapters.md#eslint)** — selected ESLint rules as Redproof Rules
+- **[`@redproof/dependency-cruiser`](https://github.com/schalermthai/redproof/blob/main/docs/built-in-adapters.md#dependency-cruiser)** — architecture and dependency boundaries
+- **[`@redproof/stryker`](https://github.com/schalermthai/redproof/blob/main/docs/built-in-adapters.md#stryker)** — mutation detection and mutation-score policies
 
-See **[Built-in integrations](https://github.com/schalermthai/redproof/blob/main/docs/adapters.md)** for examples.
+See **[Built-in Adapters](https://github.com/schalermthai/redproof/blob/main/docs/built-in-adapters.md)** for examples.
 
 ## Build your own
 
@@ -283,7 +283,7 @@ command groups, and what a Check reports about itself.
 
 See **[Composing Redproof](https://github.com/schalermthai/redproof/blob/main/docs/composition.md)** to create your own Gates, Rules, Checks, Proofs, and Mutations.
 
-See **[Building an Adapter](https://github.com/schalermthai/redproof/blob/main/docs/building-an-adapter.md)** when a tool brings its own policy model, and for the guidelines that keep an Adapter's verdicts honest.
+See **[Custom Adapter](https://github.com/schalermthai/redproof/blob/main/docs/custom-adapter.md)** when a tool brings its own policy model, and for the guidelines that keep an Adapter's verdicts honest.
 
 For execution isolation, machine-readable reports, VS Code, and other workflows, see **[Tutorials](https://github.com/schalermthai/redproof/blob/main/docs/tutorials/README.md)**.
 
@@ -355,10 +355,10 @@ npm run redproof:describe -- gates/no-todo.ts
 
 ## Learn more
 
-- **[Built-in integrations](https://github.com/schalermthai/redproof/blob/main/docs/adapters.md)**
+- **[Built-in Adapters](https://github.com/schalermthai/redproof/blob/main/docs/built-in-adapters.md)**
 - **[Command Checks](https://github.com/schalermthai/redproof/blob/main/docs/commands.md)**
 - **[Composing Redproof](https://github.com/schalermthai/redproof/blob/main/docs/composition.md)**
-- **[Building an Adapter](https://github.com/schalermthai/redproof/blob/main/docs/building-an-adapter.md)**
+- **[Custom Adapter](https://github.com/schalermthai/redproof/blob/main/docs/custom-adapter.md)**
 - **[Tutorials](https://github.com/schalermthai/redproof/blob/main/docs/tutorials/README.md)**
 - **[Legacy modernization](https://github.com/schalermthai/redproof/blob/main/docs/legacy-modernization.md)**
 - **[Self-hosting Redproof](https://github.com/schalermthai/redproof/blob/main/docs/self-hosting.md)**

--- a/docs/built-in-adapters.md
+++ b/docs/built-in-adapters.md
@@ -1,4 +1,4 @@
-# Built-in integrations
+# Built-in Adapters
 
 Redproof integrations translate an existing tool or result format into Redproof Rules and Check results.
 
@@ -128,7 +128,7 @@ report.junitXml()
 ```
 
 For a custom test system, implement only the runner or the report format. See
-**[Extend the testing adapter instead](building-an-adapter.md#extend-the-testing-adapter-instead)**.
+**[Extend the testing adapter instead](custom-adapter.md#extend-the-testing-adapter-instead)**.
 
 ### What a command runner reports about itself
 
@@ -308,6 +308,6 @@ For a useful RED proof, weaken the test suite and confirm Stryker notices the lo
 
 ## Next
 
-- **[Building an Adapter](building-an-adapter.md)** when no built-in integration fits, and for
+- **[Custom Adapter](custom-adapter.md)** when no built-in integration fits, and for
   choosing between a Check, a runner or report format, and an Adapter.
 - **[Command Checks](commands.md)** when the tool is an executable and its exit code is the result.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -4,7 +4,7 @@ A **Check** decides whether the Rules of a Gate hold. When a guardrail already
 exists as an executable, you do not need to write that Check by hand.
 
 `redproof/command` builds a Check from a command line. It is part of the Check
-layer, not an Adapter. See **[Decide what to build](building-an-adapter.md#decide-what-to-build)**
+layer, not an Adapter. See **[Decide what to build](custom-adapter.md#decide-what-to-build)**
 when you are not sure which one you need.
 
 - [One command](#one-command)
@@ -136,7 +136,7 @@ does. An explicit description always wins.
 
 - **[Composing Redproof](composition.md)** for Rules, Checks, Proofs, and
   Mutations.
-- **[Building an Adapter](building-an-adapter.md)** for tools that bring their
+- **[Custom Adapter](custom-adapter.md)** for tools that bring their
   own policy model.
-- **[Built-in integrations](adapters.md)** for the Adapters that ship with
+- **[Built-in Adapters](built-in-adapters.md)** for the Adapters that ship with
   Redproof.

--- a/docs/composition.md
+++ b/docs/composition.md
@@ -418,13 +418,13 @@ bad option                → throw before any Check exists
 
 Do not infer Redproof semantics from a process exit code when structured evidence can distinguish the two.
 
-See **[Building an Adapter](building-an-adapter.md)** for a complete example and
+See **[Custom Adapter](custom-adapter.md)** for a complete example and
 the guidelines that keep its verdicts honest.
 
 ## Next
 
-- **[Building an Adapter](building-an-adapter.md)**
-- **[Built-in integrations](adapters.md)**
+- **[Custom Adapter](custom-adapter.md)**
+- **[Built-in Adapters](built-in-adapters.md)**
 - **[Execution isolation](tutorials/execution-isolation.md)**
 - **[Reporters](tutorials/reporters.md)**
 - **[Legacy modernization](legacy-modernization.md)**

--- a/docs/custom-adapter.md
+++ b/docs/custom-adapter.md
@@ -1,11 +1,12 @@
-# Building an Adapter
+# Custom Adapter
 
-An Adapter translates an external tool into Redproof Rules and one Check. The
-tool keeps doing the real analysis. The Adapter decides what its output means.
+An Adapter translates an external tool into Redproof Rules and one Check. It
+is for a serious integration: a tool that brings its own policy model, such as
+a rule catalogue or a score. Most Gates do not need one.
 
-This page shows how to build one, and the rules that keep its verdicts honest.
-The `@redproof/testing` package follows every rule here, so its source is the
-worked example.
+This page first shows the two simpler options. Then it shows how to build an
+Adapter, and the rules that keep its verdicts honest. The `@redproof/testing`
+package follows every rule here, so its source is the worked example.
 
 - [Decide what to build](#decide-what-to-build)
 - [Three lanes for a wrong answer](#three-lanes-for-a-wrong-answer)
@@ -16,19 +17,91 @@ worked example.
 
 ## Decide what to build
 
-Three pieces can wrap a tool. Pick the smallest one that fits.
+Try the two simpler options first. Build an Adapter only when neither fits.
 
-> Create a Check when the tool is an executable and its exit code is the result.
+### A native Check with `run()`
 
-> Create a runner or a report format when the tool only changes how a test
-> suite starts, or how its results are written.
+When you can find the evidence yourself, write the Check inline. The no-todo
+Gate in the README is complete with no Adapter. It scans source files and
+reports each match as a Breach of one Rule.
+
+```ts
+import { breach, counting, defineGate, defineRules, result, text } from 'redproof';
+
+const rules = defineRules({
+  noTodo: {
+    id: 'source/no-todo',
+    description: 'Source files must not contain TODO comments.',
+  },
+});
+
+export default defineGate({
+  id: 'no-todo',
+  rules,
+
+  check: {
+    description: 'scan TypeScript source files for TODO comments',
+    counting: counting.supported,
+
+    async run(ctx) {
+      const found = await text.find(ctx, { files: 'src/**/*.ts', find: /\bTODO\b/g });
+      return result.fromBreaches(
+        found.scan(),
+        found.matches.map(match =>
+          breach(rules.noTodo, {
+            code: 'todo-found',
+            message: 'TODO comment found.',
+            location: match.location,
+          }),
+        ),
+      );
+    },
+  },
+});
+```
+
+### A Command Check that delegates to the tool
+
+When the guardrail already exists as an executable, `redproof/command` builds
+the Check for you. The exit code decides the verdict. A missing executable, a
+timeout, or an exit code outside the policy becomes REFUSE.
+
+```ts
+import { defineGate, defineRules } from 'redproof';
+import { command } from 'redproof/command';
+
+const rules = defineRules({
+  docs: {
+    id: 'docs/lint',
+    description: 'Documentation must pass lint.',
+  },
+});
+
+export default defineGate({
+  id: 'docs',
+  rules,
+  check: command({
+    rule: rules.docs,
+    command: 'npm',
+    args: ['run', 'lint:docs'],
+  }),
+});
+```
+
+See **[Command Checks](commands.md)** for exit-code policy, command groups, and
+what a Check reports about itself.
+
+### An Adapter
 
 > Create an Adapter when the tool brings its own policy model, such as a rule
-> catalogue or a score.
+> catalogue or a score, and one Gate must expose several of its policies as
+> Redproof Rules.
 
-For the first case, `redproof/command` builds the Check for you. See
-**[Command Checks](commands.md)**. For the second case, see
-[Extend the testing adapter instead](#extend-the-testing-adapter-instead).
+> Create a runner or a report format, not an Adapter, when the tool only changes
+> how a test suite starts, or how its results are written. See
+> [Extend the testing adapter instead](#extend-the-testing-adapter-instead).
+
+The rest of this page is for the Adapter case.
 
 ## Three lanes for a wrong answer
 
@@ -319,4 +392,4 @@ kinds against one Adapter.
 
 - **[Composing Redproof](composition.md)** for Rules, Checks, Proofs, and Mutations.
 - **[Command Checks](commands.md)** for a guardrail that is already an executable.
-- **[Built-in integrations](adapters.md)** for the Adapters that ship with Redproof.
+- **[Built-in Adapters](built-in-adapters.md)** for the Adapters that ship with Redproof.

--- a/docs/legacy-modernization.md
+++ b/docs/legacy-modernization.md
@@ -419,5 +419,5 @@ Together, the two directions cover the whole strangler program. One set of Gates
 ## Next
 
 - **[Composing Redproof](composition.md)** for authoring Rules, Checks, Proofs, Mutations, and Adapters
-- **[Built-in integrations](adapters.md)** for the testing, ESLint, dependency-cruiser, and Stryker Adapters
+- **[Built-in Adapters](built-in-adapters.md)** for the testing, ESLint, dependency-cruiser, and Stryker Adapters
 - **[Execution isolation](tutorials/execution-isolation.md)** for running proof mutations against copied workspaces

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -28,4 +28,4 @@ For a guardrail that is already an executable, see **[Command Checks](../command
 
 For authoring Rules, Checks, Proofs, and Mutations, see **[Composing Redproof](../composition.md)**.
 
-For wrapping a tool that brings its own policy model, see **[Building an Adapter](../building-an-adapter.md)**.
+For wrapping a tool that brings its own policy model, see **[Custom Adapter](../custom-adapter.md)**.


### PR DESCRIPTION
## Problem

After #55 the two adapter pages had names that did not match their subjects. `docs/adapters.md` held only the built-in Adapters. `docs/building-an-adapter.md` opened with the Adapter case, so a reader could start a custom Adapter for a guardrail that a plain `run()` Check or a Command Check already covers.

## Fix

Rename `docs/adapters.md` to `docs/built-in-adapters.md`, and `docs/building-an-adapter.md` to `docs/custom-adapter.md`. Every link in the README, the docs, and the tutorials index follows the new names. The page title and link text become "Built-in Adapters" and "Custom Adapter".

The custom adapter guide now opens by saying an Adapter is for a serious integration, and most Gates do not need one. Its first section shows the two simpler options with checked examples: a native Check with `run()`, like the no-todo Gate, and a Command Check that delegates to the tool. The Adapter case follows.

## Verification

- `npm run docs:typecheck`: 23 checked examples across 11 documents, all pass.
- Fragment budget: 37 of 37, unchanged.
- `npm run self:check`: 4 of 4 Gates, 22 of 22 Rules, including `repository/docs-relative-links-resolve` against the renamed files.
- `npm run self:prove`: 27 of 27 proofs.
