### PR TITLE
Refuse vacuous Gate passes

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,11 @@ FAIL     one or more Rules were breached
 REFUSE   the Check could not decide safely
 ```
 
+A PASS that inspected zero targets becomes REFUSE by default, because it cannot
+establish the Gate's Rules. A Gate whose empty scope is intentionally valid can
+set `allowEmptyInspection: true`; unknown counts (`inspected: null`) are not
+treated as zero.
+
 ## Built-in Adapters
 
 You do not need to build every Gate yourself.

--- a/docs/built-in-adapters.md
+++ b/docs/built-in-adapters.md
@@ -4,6 +4,8 @@ Redproof integrations translate an existing tool or result format into Redproof 
 
 The external tool remains responsible for doing the real analysis. Redproof adds the Rule model and proofs around it.
 
+Every Adapter reports how many targets it inspected. A PASS over zero targets is refused as `nothing-inspected` unless the Gate sets `allowEmptyInspection: true`. See [Empty inspection](composition.md#empty-inspection).
+
 ## Testing
 
 Package:

--- a/docs/composition.md
+++ b/docs/composition.md
@@ -222,6 +222,43 @@ const scan = {
 
 That matters because a Check declaring `counting.supported` promises a reliable count.
 
+## Empty inspection
+
+A Gate refuses an otherwise successful Check when `scan.inspected` is `0`.
+Without a target, PASS would claim that every Rule holds without inspecting the
+scope the Gate promises to protect. The Check's report remains valid; Redproof
+changes only the Gate verdict to REFUSE with the `nothing-inspected` diagnostic.
+
+When an empty target set is intentionally valid, opt in on that Gate:
+
+```ts
+import { counting, defineAdapter, defineGate, pass } from 'redproof';
+
+const adapter = defineAdapter({
+  kind: 'optional-files',
+  rules: {
+    valid: { id: 'optional-files/valid', description: 'Optional files are valid.' },
+  },
+  check: {
+    description: 'inspect optional generated files',
+    counting: counting.supported,
+    async run() {
+      return pass({ source: 'optional-files', startedAt: '', finishedAt: '', inspected: 0 });
+    },
+  },
+});
+
+defineGate({
+  id: 'optional-generated-files',
+  adapter,
+  allowEmptyInspection: true,
+})
+```
+
+Use the exception narrowly. `inspected: null` means the Check cannot count its
+targets and is not treated as zero; FAIL and REFUSE results keep their original
+evidence even when their scan count is zero.
+
 ## Proofs
 
 A RED proof targets one specific Rule:

--- a/docs/custom-adapter.md
+++ b/docs/custom-adapter.md
@@ -209,6 +209,11 @@ cannot evaluate reliably  → Diagnostic → REFUSE
 bad option                → throw before any Check exists
 ```
 
+The Gate boundary also protects every Adapter from a vacuous success: a PASS
+with `scan.inspected === 0` becomes `nothing-inspected` REFUSE by default. Keep
+valid empty reports parseable, and use `allowEmptyInspection: true` on the Gate
+only when an empty target set is part of that Gate's declared policy.
+
 ## Guidelines
 
 ### 1. Validate options in the constructor and throw

--- a/packages/redproof/src/composition/core/gate.ts
+++ b/packages/redproof/src/composition/core/gate.ts
@@ -4,6 +4,8 @@ export type NativeGateDefinition<C extends RuleCatalog> = {
   readonly id: string;
   readonly rules: C;
   readonly check: Check<RuleRefOfCatalog<C>>;
+  /** Permit PASS when the Check reports that it inspected zero targets. Defaults to false. */
+  readonly allowEmptyInspection?: boolean;
 };
 
 export function defineGate<const A extends Adapter<any>>(gate: Gate<A>): Gate<A>;
@@ -20,5 +22,8 @@ export function defineGate(
       rules: gate.rules,
       check: gate.check,
     },
+    ...(gate.allowEmptyInspection === undefined
+      ? {}
+      : { allowEmptyInspection: gate.allowEmptyInspection }),
   };
 }

--- a/packages/redproof/src/domain/gate.ts
+++ b/packages/redproof/src/domain/gate.ts
@@ -3,6 +3,8 @@ import type { Adapter, RuleRefOfAdapter } from './adapter.ts';
 export type Gate<A extends Adapter<any> = Adapter<any>> = {
   readonly id: string;
   readonly adapter: A;
+  /** Permit PASS when the Check reports that it inspected zero targets. Defaults to false. */
+  readonly allowEmptyInspection?: boolean;
 };
 
 export type RuleRefOfGate<G extends Gate<any>> = RuleRefOfAdapter<G['adapter']>;

--- a/packages/redproof/src/project/core/description.ts
+++ b/packages/redproof/src/project/core/description.ts
@@ -17,6 +17,7 @@ export type GateDescription = {
   readonly gate: string;
   readonly rules: readonly DescribedRule[];
   readonly check: string;
+  readonly allowEmptyInspection: boolean;
   readonly proofs: readonly DescribedProof[];
 };
 
@@ -59,6 +60,7 @@ export function describeModule(module: LoadedGateModule): GateDescription {
     gate: module.gate.id,
     rules,
     check: module.gate.adapter.check.description,
+    allowEmptyInspection: module.gate.allowEmptyInspection === true,
     proofs,
   };
 }

--- a/packages/redproof/src/proof/core/index.ts
+++ b/packages/redproof/src/proof/core/index.ts
@@ -5,6 +5,7 @@ export type {
   RefuseProofEvaluation,
 } from './evaluation.ts';
 export { proofEstablished } from './outcome.ts';
+export { applyInspectionPolicy } from './inspection.ts';
 export type {
   AbortedProofOutcome,
   CompletedProofOutcome,

--- a/packages/redproof/src/proof/core/inspection.ts
+++ b/packages/redproof/src/proof/core/inspection.ts
@@ -1,0 +1,25 @@
+import type { CheckResult } from '../../domain/index.ts';
+
+/**
+ * A PASS proves nothing when a Check inspected no targets. Keep the
+ * Check's scan as evidence and turn only that vacuous success into REFUSE.
+ */
+export function applyInspectionPolicy(
+  result: CheckResult,
+  allowEmptyInspection: boolean,
+): CheckResult {
+  if (result.verdict !== 'pass' || result.scan.inspected !== 0 || allowEmptyInspection) {
+    return result;
+  }
+
+  return {
+    verdict: 'refuse',
+    scan: result.scan,
+    why: {
+      code: 'nothing-inspected',
+      message: 'The Check inspected no targets, so the Gate cannot establish its Rules.',
+      location: null,
+      hint: 'Set allowEmptyInspection: true on the Gate only when an empty target set is intentional.',
+    },
+  };
+}

--- a/packages/redproof/src/proof/shell/runner.ts
+++ b/packages/redproof/src/proof/shell/runner.ts
@@ -13,6 +13,7 @@ import {
   completedOutcome,
   failedOutcome,
 } from '../core/lifecycle.ts';
+import { applyInspectionPolicy } from '../core/inspection.ts';
 import type { ProofOutcome } from '../core/outcome.ts';
 
 function ruleRefs(adapter: Adapter<any>): RuleRef[] {
@@ -20,7 +21,8 @@ function ruleRefs(adapter: Adapter<any>): RuleRef[] {
 }
 
 export async function runGate(gate: Gate<any>, root: string): Promise<CheckResult> {
-  return gate.adapter.check.run({ root, rules: ruleRefs(gate.adapter) });
+  const result = await gate.adapter.check.run({ root, rules: ruleRefs(gate.adapter) });
+  return applyInspectionPolicy(result, gate.allowEmptyInspection === true);
 }
 
 async function applyMutations(root: string, plan: MutationPlan | undefined): Promise<UndoMutation[]> {

--- a/packages/redproof/src/reporter/core/terminal.ts
+++ b/packages/redproof/src/reporter/core/terminal.ts
@@ -62,7 +62,10 @@ function gateStatusSuffix(run: GateRun): string {
   const ruleCount = model.rules.length;
   const label = `${ruleCount} ${ruleCount === 1 ? 'rule' : 'rules'}`;
 
-  if (model.verdict === 'pass') return `(${label})`;
+  if (model.verdict === 'pass') {
+    const inspection = run.result.scan.inspected === 0 ? ' | 0 inspected' : '';
+    return `(${label}${inspection})`;
+  }
   if (model.verdict === 'refuse') return `(${label} | refused)`;
   if (model.counting.kind === 'unsupported') return `(${label} | breach detected)`;
 

--- a/packages/redproof/src/reporter/core/terminal.ts
+++ b/packages/redproof/src/reporter/core/terminal.ts
@@ -318,6 +318,7 @@ export function formatGateDescription(description: GateDescription): string {
   }
 
   lines.push('', 'Check:', ...indentDescription(description.check));
+  if (description.allowEmptyInspection) lines.push('', 'Empty scope: allowed');
 
   for (const item of description.proofs) {
     const label = item.kind === 'red' ? item.targetLabel ?? 'RED' : item.kind.toUpperCase();

--- a/scripts/verify-package.ts
+++ b/scripts/verify-package.ts
@@ -242,13 +242,16 @@ try {
     + "export const group = commands({ entries: [{ rule, command: 'node' }] });\n"
     + "export const mutation = stryker({ cwd: 'packages/parser', rules: { noNewUndetectedMutants: { acceptedMutantsFile: 'accepted-mutants.json' } } });\n"
     + "export const tests = vitest({ cwd: 'packages/parser', reportFile: 'results.json', rules: { testsPass: true, noFlakyTests: true } });\n"
+    + "export const optional = defineGate({ id: 'optional', rules: { command: rule }, check, allowEmptyInspection: true });\n"
     + "export const gate = defineGate;\n";
   await writeFile(join(consumer, 'consumer.ts'), green);
   const typesOk = tryRun(tsc, ['-p', 'tsconfig.json'], consumer);
   report(typesOk.ok, 'valid consumer code type-checks', typesOk.ok ? '' : typesOk.output.slice(0, 400));
 
   console.log('\n7. Red-proof: the type check must reject bad code');
-  const red = "import { thisExportDoesNotExist } from 'redproof';\nvoid thisExportDoesNotExist;\n";
+  const red = "import { counting, defineGate, pass } from 'redproof';\n"
+    + "const rule = { id: 'consumer/rule', description: 'rule' } as const;\n"
+    + "defineGate({ id: 'bad', rules: { rule }, check: { description: 'check', counting: counting.supported, async run() { return pass({ source: 'consumer', startedAt: '', finishedAt: '', inspected: 0 }); } }, allowEmptyInspection: 'yes' });\n";
   await writeFile(join(consumer, 'consumer.ts'), red);
   const typesRed = tryRun(tsc, ['-p', 'tsconfig.json'], consumer);
   report(!typesRed.ok, 'invalid consumer code is rejected', typesRed.ok ? 'type check passed when it should have failed' : '');

--- a/scripts/verify-package.ts
+++ b/scripts/verify-package.ts
@@ -254,7 +254,12 @@ try {
     + "defineGate({ id: 'bad', rules: { rule }, check: { description: 'check', counting: counting.supported, async run() { return pass({ source: 'consumer', startedAt: '', finishedAt: '', inspected: 0 }); } }, allowEmptyInspection: 'yes' });\n";
   await writeFile(join(consumer, 'consumer.ts'), red);
   const typesRed = tryRun(tsc, ['-p', 'tsconfig.json'], consumer);
-  report(!typesRed.ok, 'invalid consumer code is rejected', typesRed.ok ? 'type check passed when it should have failed' : '');
+  const redNamesPolicy = typesRed.output.includes("not assignable to type 'boolean");
+  report(
+    !typesRed.ok && redNamesPolicy,
+    'invalid consumer code is rejected for the planted reason',
+    typesRed.ok ? 'type check passed when it should have failed' : redNamesPolicy ? '' : typesRed.output.slice(0, 400),
+  );
 
   console.log('\n8. Check every package carries the same version');
   const versions = new Set<string>();

--- a/skills/redproof/breaking.md
+++ b/skills/redproof/breaking.md
@@ -41,7 +41,10 @@ redproof check --reporter=json --outputFile=out.json
 Every Check result carries a `scan` with an `inspected` count. The ESLint
 adapter sets it to the number of linted files, at
 `packages/eslint/src/index.ts`. An `inspected` value of zero is the answer. The
-check is blind, and no break is needed.
+check is blind, and no break is needed. Redproof refuses that PASS on its own
+with the `nothing-inspected` diagnostic. A Gate that sets
+`allowEmptyInspection: true` keeps the PASS, so read that flag as a claim to
+verify.
 
 Other tools expose the same thing under other names. A test count, a file count,
 a duration. When the number is zero, stop and fix the check.

--- a/tests/adapters/testing.test.ts
+++ b/tests/adapters/testing.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import test from 'node:test';
 import { testing, report, runner, parseJestJson, parseJunitXml, testRunBreaches, vitest, type TestRunner } from '@redproof/testing';
-import { defineRule } from 'redproof';
+import { defineGate, defineRule, runGate } from 'redproof';
 import { configuredVitestReport } from '../../packages/testing/src/shell/vitest-runner.ts';
 import { withWorkspace } from '../helpers/workspace.ts';
 
@@ -400,6 +400,44 @@ test('testing adapter refuses an unexplained non-zero exit even when an empty re
     if (result.verdict !== 'refuse') return;
     assert.equal(result.why.code, 'test-runner-unsuccessful');
     assert.match(result.why.detail ?? '', /exit code: 5/);
+  });
+});
+
+test('a valid empty Vitest-compatible report passes parsing but is refused by the Gate by default', async () => {
+  await withWorkspace(async root => {
+    const runner: TestRunner = {
+      description: 'write an empty Vitest-compatible report',
+      async run(ctx) {
+        await writeFile(ctx.reportFile, JSON.stringify({
+          success: true,
+          numTotalTests: 0,
+          numPassedTests: 0,
+          numFailedTests: 0,
+          numPendingTests: 0,
+          numTodoTests: 0,
+          testResults: [],
+        }), 'utf8');
+        return { kind: 'completed', exitCode: 0, stdout: '', stderr: '' };
+      },
+    };
+    const adapter = testing({
+      runner,
+      report: report.jestJson(),
+      rules: { testsPass: true },
+    });
+
+    const parsed = await adapter.check.run({ root, rules: [adapter.rules.testsPass.id] });
+    assert.equal(parsed.verdict, 'pass', 'an empty but internally consistent report is trustworthy');
+    assert.equal(parsed.scan.inspected, 0);
+
+    const guarded = await runGate(defineGate({ id: 'tests', adapter }), root);
+    assert.equal(guarded.verdict, 'refuse');
+    if (guarded.verdict !== 'refuse') return;
+    assert.equal(guarded.why.code, 'nothing-inspected');
+
+    const allowed = await runGate(defineGate({ id: 'optional-tests', adapter, allowEmptyInspection: true }), root);
+    assert.equal(allowed.verdict, 'pass');
+    assert.equal(allowed.scan.inspected, 0);
   });
 });
 

--- a/tests/composition/api.test.ts
+++ b/tests/composition/api.test.ts
@@ -32,6 +32,7 @@ test('defineRules preserves aliases and native defineGate supplies only native a
 
   const gate = defineGate({
     id: 'source-markers',
+    allowEmptyInspection: true,
     rules,
     check: {
       description: 'check source markers',
@@ -43,6 +44,7 @@ test('defineRules preserves aliases and native defineGate supplies only native a
   assert.equal(gate.adapter.kind, 'native');
   assert.equal(gate.adapter.rules.noTodo, rules.noTodo);
   assert.equal(gate.adapter.rules.noFixme, rules.noFixme);
+  assert.equal(gate.allowEmptyInspection, true);
 });
 
 test('defineCheck binds a reusable Check to an explicit Rule catalog', () => {

--- a/tests/proof.core.test.ts
+++ b/tests/proof.core.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { breach, fail, pass, proof, proofEstablished, refuse, type Scan } from 'redproof';
 import { evaluateProof } from '../packages/redproof/src/proof/core/evaluation.ts';
+import { applyInspectionPolicy } from '../packages/redproof/src/proof/core/inspection.ts';
 import type { ProofOutcome } from '../packages/redproof/src/proof/core/outcome.ts';
 import { canReuseWorkspace, verifyProofRestoration } from '../packages/redproof/src/proof/core/restoration.ts';
 
@@ -15,6 +16,33 @@ const scan: Scan = {
 const R1 = { id: 'r1', description: 'R1' } as const;
 const R2 = { id: 'r2', description: 'R2' } as const;
 const noop = { description: 'noop', async apply() { return async () => {}; } };
+
+test('a zero-inspected PASS becomes REFUSE unless the Gate explicitly allows it', () => {
+  const emptyScan: Scan = { ...scan, inspected: 0 };
+  const emptyPass = pass(emptyScan);
+
+  assert.deepEqual(applyInspectionPolicy(emptyPass, false), refuse(emptyScan, {
+    code: 'nothing-inspected',
+    message: 'The Check inspected no targets, so the Gate cannot establish its Rules.',
+    location: null,
+    hint: 'Set allowEmptyInspection: true on the Gate only when an empty target set is intentional.',
+  }));
+  assert.equal(applyInspectionPolicy(emptyPass, true), emptyPass);
+});
+
+test('inspection policy preserves unknown counts and non-PASS evidence', () => {
+  const unknownPass = pass({ ...scan, inspected: null });
+  const emptyFailure = fail({ ...scan, inspected: 0 }, [
+    breach(R1.id, { code: 'r1', message: 'R1 failed', location: null }),
+  ]);
+  const emptyRefusal = refuse({ ...scan, inspected: 0 }, {
+    code: 'unavailable', message: 'Unavailable', location: null,
+  });
+
+  assert.equal(applyInspectionPolicy(unknownPass, false), unknownPass);
+  assert.equal(applyInspectionPolicy(emptyFailure, false), emptyFailure);
+  assert.equal(applyInspectionPolicy(emptyRefusal, false), emptyRefusal);
+});
 
 test('RED proof requires its target Rule, not merely a failed Gate', () => {
   const result = fail(scan, [

--- a/tests/proof.test.ts
+++ b/tests/proof.test.ts
@@ -33,17 +33,19 @@ type World = {
   breached: readonly RuleId[];
   refused: boolean;
   checkThrows: boolean;
+  inspected: number | null;
   readonly contexts: CheckContext[];
   readonly log: string[];
 };
 
 function world(overrides: Partial<World> = {}): World {
-  return { breached: [], refused: false, checkThrows: false, contexts: [], log: [], ...overrides };
+  return { breached: [], refused: false, checkThrows: false, inspected: 1, contexts: [], log: [], ...overrides };
 }
 
-function gateOver(state: World) {
+function gateOver(state: World, allowEmptyInspection = false) {
   return defineGate({
     id: 'world',
+    ...(allowEmptyInspection ? { allowEmptyInspection: true } : {}),
     adapter: defineAdapter({
       kind: 'test',
       rules: { r1: R1, r2: R2 },
@@ -53,10 +55,11 @@ function gateOver(state: World) {
         async run(ctx) {
           state.contexts.push(ctx);
           if (state.checkThrows) throw new Error('check exploded');
-          if (state.refused) return refuse(scan, { code: 'unavailable', message: 'Unavailable', location: null });
+          const checkScan = { ...scan, inspected: state.inspected };
+          if (state.refused) return refuse(checkScan, { code: 'unavailable', message: 'Unavailable', location: null });
           const [first, ...rest] = state.breached.map(rule =>
             breach(rule, { code: rule, message: `${rule} breached`, location: null }));
-          return first ? fail(scan, [first, ...rest]) : pass(scan);
+          return first ? fail(checkScan, [first, ...rest]) : pass(checkScan);
         },
       },
     }),
@@ -104,6 +107,20 @@ test('runGate hands the Check its root and every Rule of the Adapter', async () 
 
   assert.equal(result.verdict, 'pass');
   assert.deepEqual(state.contexts, [{ root: '/project', rules: ['r1', 'r2'] }]);
+});
+
+test('runGate refuses a zero-inspected PASS by default and permits an explicit empty scope', async () => {
+  const state = world({ inspected: 0 });
+
+  const guarded = await runGate(gateOver(state), '/project');
+  assert.equal(guarded.verdict, 'refuse');
+  if (guarded.verdict !== 'refuse') throw new Error('expected refusal');
+  assert.equal(guarded.why.code, 'nothing-inspected');
+  assert.equal(guarded.scan.inspected, 0);
+
+  const allowed = await runGate(gateOver(state, true), '/project');
+  assert.equal(allowed.verdict, 'pass');
+  assert.equal(allowed.scan.inspected, 0);
 });
 
 test('RED proof proves when its mutation breaches the target, then restores the world', async () => {

--- a/tests/reporter.core.test.ts
+++ b/tests/reporter.core.test.ts
@@ -2,7 +2,8 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { breach, counting, defineAdapter, defineGate, fail, formatProof, pass, refuse, type CheckResult, type CompletedProofOutcome, type ProofOutcome, type Scan } from 'redproof';
 import type { CheckProjectRun } from '../packages/redproof/src/run/core/run.ts';
-import { renderRun } from '../packages/redproof/src/reporter/core/terminal.ts';
+import { formatGateDescription, renderRun } from '../packages/redproof/src/reporter/core/terminal.ts';
+import { describeModule } from '../packages/redproof/src/project/core/description.ts';
 
 const scan: Scan = { source: 'unit', startedAt: '', finishedAt: '', inspected: 1 };
 const R1 = { id: 'unit/r1', description: 'R1' } as const;
@@ -54,6 +55,21 @@ test('a diagnostic without a line never asks for source', () => {
 
   assert.match(output, / ❯ src\/a\.ts\n\n   R1 breached/);
   assert.doesNotMatch(output, /ignored/);
+});
+
+test('describe shows an allowed empty scope and stays silent otherwise', () => {
+  const adapter = defineAdapter({
+    kind: 'described',
+    rules: { r1: { id: 'r1', description: 'R1' } },
+    check: { description: 'inspect', counting: counting.supported, async run() { return pass(scan); } },
+  });
+  const quiet = describeModule({ file: 'gates/quiet.ts', gate: defineGate({ id: 'quiet', adapter, allowEmptyInspection: true }) });
+  const strict = describeModule({ file: 'gates/strict.ts', gate: defineGate({ id: 'strict', adapter }) });
+
+  assert.equal(quiet.allowEmptyInspection, true);
+  assert.equal(strict.allowEmptyInspection, false);
+  assert.match(formatGateDescription(quiet), /Check:\n  inspect\n\nEmpty scope: allowed/);
+  assert.doesNotMatch(formatGateDescription(strict), /Empty scope/);
 });
 
 test('terminal output makes an explicitly allowed zero-inspection PASS visible', () => {

--- a/tests/reporter.core.test.ts
+++ b/tests/reporter.core.test.ts
@@ -56,6 +56,12 @@ test('a diagnostic without a line never asks for source', () => {
   assert.doesNotMatch(output, /ignored/);
 });
 
+test('terminal output makes an explicitly allowed zero-inspection PASS visible', () => {
+  const output = renderRun(runWith(pass({ ...scan, inspected: 0 })), new Map());
+
+  assert.match(output, /gates\/unit\.ts \(1 rule \| 0 inspected\)/);
+});
+
 function completed<E extends CompletedProofOutcome['expected']>(
   expected: E,
   reason: Extract<CompletedProofOutcome, { expected: E }>['reason'],

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -139,6 +139,10 @@ const adapter = defineAdapter({
   },
 });
 const gate = defineGate({ id: 'g', adapter });
+defineGate({ id: 'optional', adapter, allowEmptyInspection: true });
+
+// @ts-expect-error empty-inspection policy is boolean.
+defineGate({ id: 'bad-policy', adapter, allowEmptyInspection: 'yes' });
 
 defineProofs(gate, [proof.green('green')]);
 
@@ -153,6 +157,7 @@ const composedRules = defineRules({
 
 const nativeGate = defineGate({
   id: 'native-composed',
+  allowEmptyInspection: false,
   rules: composedRules,
   check: defineCheck(composedRules, {
     description: 'native composed check',


### PR DESCRIPTION
## Summary

- turn PASS with an exact zero inspected count into nothing-inspected REFUSE at the shared Gate boundary
- add a per-Gate allowEmptyInspection opt-out for intentionally optional scopes
- preserve valid empty adapter reports, unknown counts, failures, and existing refusals
- make an allowed zero-inspection PASS visible in terminal output
- document the policy and verify its packed public types

## Why the Gate boundary

Vitest passWithNoTests can produce a valid empty Jest-compatible report and exit successfully. Rejecting that report in the testing parser would conflate trustworthy structure with project policy and would leave ESLint, Stryker, native, and custom adapters exposed to the same vacuous success. runGate is the shared boundary for check and proof execution in both in-place and copies modes.

## Verification

- npm run check: 242/242 native tests, 4/4 self-Gates, 22/22 Rules, all causal self-proofs
- npm run verify:package: all tarball, runtime, CLI, metadata, version, and clean-consumer type checks
- focused Vitest-compatible regression proves empty report parsing remains valid before Gate policy is applied

## Compatibility

This intentionally changes a Gate that previously returned PASS with scan.inspected equal to 0 into REFUSE. Gates whose empty scope is meaningful can opt in explicitly. scan.inspected equal to null remains an unknown count, not an empty count.

Written by an AI agent on behalf of @schalermthai; it has not yet been reviewed by a human.