### PR TITLE
Terminate timed-out command process trees

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ const gate = defineGate({
 });
 ```
 
-Completed failure exits breach the selected Rule. Missing executables, timeouts, signals, output overflow, and explicitly unclassified exits produce **REFUSE**. Use `commands()` from the same subpath for deterministic sequential or bounded-parallel command groups.
+Completed failure exits breach the selected Rule. Missing executables, timeouts, signals, output overflow, and explicitly unclassified exits produce **REFUSE**. Timeouts and output overflow terminate the complete child-process tree before returning. Use `commands()` from the same subpath for deterministic sequential or bounded-parallel command groups.
 
 See **[Command Checks](https://github.com/schalermthai/redproof/blob/main/docs/commands.md)** for exit-code policy,
 command groups, and what a Check reports about itself.

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ const gate = defineGate({
 });
 ```
 
-Completed failure exits breach the selected Rule. Missing executables, timeouts, signals, output overflow, and explicitly unclassified exits produce **REFUSE**. Timeouts and output overflow terminate the complete child-process tree before returning. Use `commands()` from the same subpath for deterministic sequential or bounded-parallel command groups.
+Completed failure exits breach the selected Rule. Missing executables, timeouts, signals, output overflow, and explicitly unclassified exits produce **REFUSE**. Each command runs in its own process group. Timeouts, output overflow, and an interrupted Redproof process stop that group. Use `commands()` from the same subpath for deterministic sequential or bounded-parallel command groups.
 
 See **[Command Checks](https://github.com/schalermthai/redproof/blob/main/docs/commands.md)** for exit-code policy,
 command groups, and what a Check reports about itself.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -10,6 +10,7 @@ when you are not sure which one you need.
 - [One command](#one-command)
 - [Exit codes decide the verdict](#exit-codes-decide-the-verdict)
 - [When a command REFUSES](#when-a-command-refuses)
+- [Reuse process execution](#reuse-process-execution)
 - [Several commands](#several-commands)
 - [Order and precedence](#order-and-precedence)
 - [What a Check says about itself](#what-a-check-says-about-itself)
@@ -32,7 +33,8 @@ const check = command({
 
 Relative `cwd` values resolve inside the Gate workspace and cannot escape it.
 Child output is captured for diagnostics. It is never inherited by reporter
-output, so a machine-readable report stays clean.
+output, so a machine-readable report stays clean. A timeout or output overflow
+terminates the complete process tree before the Check returns.
 
 ## Exit codes decide the verdict
 
@@ -67,6 +69,34 @@ pass, and it is never a rule breach. These five cases produce it.
 - The process is terminated by a signal.
 - Combined stdout and stderr exceed `maxOutputBytes`, which defaults to 10 MiB.
 - The process returns an exit code that no explicit policy covers.
+
+## Reuse process execution
+
+An Adapter that needs to parse structured output can reuse the same supervised
+process shell without adopting the command Check's exit-code policy:
+
+```ts
+import { executeCommand } from 'redproof/command';
+
+const execution = await executeCommand({
+  command: process.execPath,
+  args: ['tool.mjs', '--json'],
+  cwd: process.cwd(),
+  timeoutMs: 60_000,
+  maxOutputBytes: 10 * 1024 * 1024,
+});
+
+if (execution.kind === 'completed') {
+  console.log(execution.exitCode, execution.stdout, execution.stderr);
+} else {
+  console.error(execution.code, execution.message, execution.detail);
+}
+```
+
+`executeCommand()` owns spawning, bounded capture, timeout, signal handling,
+and process-tree termination. It does not decide PASS, FAIL, or which Rule an
+exit code breaches. The caller owns that policy and must supply an absolute,
+already-confined `cwd`.
 
 ## Several commands
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -33,8 +33,11 @@ const check = command({
 
 Relative `cwd` values resolve inside the Gate workspace and cannot escape it.
 Child output is captured for diagnostics. It is never inherited by reporter
-output, so a machine-readable report stays clean. A timeout or output overflow
-terminates the complete process tree before the Check returns.
+output, so a machine-readable report stays clean. Each command runs in its own
+process group with no terminal, so it cannot prompt. A timeout or output
+overflow stops that group before the Check returns. A process that starts its
+own session is outside the group. Bad options throw at once, before any process
+starts.
 
 ## Exit codes decide the verdict
 
@@ -78,10 +81,12 @@ process shell without adopting the command Check's exit-code policy:
 ```ts
 import { executeCommand } from 'redproof/command';
 
+declare const root: string;
+
 const execution = await executeCommand({
   command: process.execPath,
   args: ['tool.mjs', '--json'],
-  cwd: process.cwd(),
+  cwd: root,
   timeoutMs: 60_000,
   maxOutputBytes: 10 * 1024 * 1024,
 });
@@ -93,10 +98,12 @@ if (execution.kind === 'completed') {
 }
 ```
 
-`executeCommand()` owns spawning, bounded capture, timeout, signal handling,
-and process-tree termination. It does not decide PASS, FAIL, or which Rule an
-exit code breaches. The caller owns that policy and must supply an absolute,
-already-confined `cwd`.
+`executeCommand()` owns spawning, bounded capture, timeout, and process-group
+termination. It forwards SIGINT, SIGTERM, and SIGHUP from its own process to
+the group, and it kills the group when its own process exits. It does not
+decide PASS, FAIL, or which Rule an exit code breaches. The caller owns that
+policy and must supply an absolute `cwd` that it has already confined, such as
+the Gate root.
 
 ## Several commands
 

--- a/gates/support/effects-model.ts
+++ b/gates/support/effects-model.ts
@@ -29,6 +29,7 @@ const APPROVED_EFFECT_BOUNDARIES = new Set([
   'packages/redproof/src/cli.ts',
   'packages/redproof/src/cli/shell/main.ts',
   'packages/redproof/src/command/shell/check.ts',
+  'packages/redproof/src/command/shell/process-tree.ts',
   'packages/redproof/src/command/shell/spawn.ts',
   'packages/redproof/src/inspect/shell/files.ts',
   'packages/redproof/src/inspect/shell/search.ts',

--- a/packages/redproof/src/command/core/index.ts
+++ b/packages/redproof/src/command/core/index.ts
@@ -1,2 +1,8 @@
 export type { CommandExitCodes } from './exit-codes.ts';
-export type { CommandCheckOptions, CommandGroupExecution, CommandGroupOptions } from './options.ts';
+export type {
+  CommandCheckOptions,
+  CommandExecutionOptions,
+  CommandGroupExecution,
+  CommandGroupOptions,
+} from './options.ts';
+export type { CommandExecution, CompletedCommand, RefusedCommand } from './outcome.ts';

--- a/packages/redproof/src/command/core/options.ts
+++ b/packages/redproof/src/command/core/options.ts
@@ -1,22 +1,27 @@
-import { basename } from 'node:path';
+import { basename, isAbsolute } from 'node:path';
 import type { Rule, RuleRef } from '../../domain/index.ts';
 import type { CommandExitCodes } from './exit-codes.ts';
 
 export const DEFAULT_MAX_OUTPUT_BYTES = 10 * 1024 * 1024;
 export const DEFAULT_MAX_AT_ONCE = 4;
 
-export type CommandCheckOptions<R extends RuleRef> = {
-  readonly rule: Rule<R>;
+export type CommandExecutionOptions = {
   readonly command: string;
   readonly args?: readonly string[];
   readonly label?: string;
-  readonly description?: string;
-  /** Relative to the Gate root and confined inside it. Defaults to the root. */
-  readonly cwd?: string;
+  /** Absolute working directory already chosen and confined by the caller. */
+  readonly cwd: string;
   readonly env?: Readonly<Record<string, string | undefined>>;
   readonly timeoutMs?: number;
   /** Combined stdout and stderr capture limit. Defaults to 10 MiB. */
   readonly maxOutputBytes?: number;
+};
+
+export type CommandCheckOptions<R extends RuleRef> = Omit<CommandExecutionOptions, 'cwd'> & {
+  readonly rule: Rule<R>;
+  readonly description?: string;
+  /** Relative to the Gate root and confined inside it. Defaults to the root. */
+  readonly cwd?: string;
   readonly exitCodes?: CommandExitCodes;
 };
 
@@ -43,10 +48,19 @@ function validatePositiveInteger(name: string, value: number | undefined): void 
   }
 }
 
-export function validateCommandOptions(options: CommandCheckOptions<RuleRef>): void {
+function validateProcessOptions(options: Omit<CommandExecutionOptions, 'cwd'>): void {
   if (!options.command.trim()) throw new Error('command must not be empty.');
   validatePositiveInteger('timeoutMs', options.timeoutMs);
   validatePositiveInteger('maxOutputBytes', options.maxOutputBytes);
+}
+
+export function validateCommandExecutionOptions(options: CommandExecutionOptions): void {
+  validateProcessOptions(options);
+  if (!isAbsolute(options.cwd)) throw new Error('executeCommand cwd must be absolute.');
+}
+
+export function validateCommandOptions(options: CommandCheckOptions<RuleRef>): void {
+  validateProcessOptions(options);
 }
 
 export function validateGroupOptions(options: CommandGroupOptions<RuleRef>): void {

--- a/packages/redproof/src/command/index.ts
+++ b/packages/redproof/src/command/index.ts
@@ -1,2 +1,12 @@
-export type { CommandCheckOptions, CommandExitCodes, CommandGroupExecution, CommandGroupOptions } from './core/index.ts';
+export type {
+  CommandCheckOptions,
+  CommandExecution,
+  CommandExecutionOptions,
+  CommandExitCodes,
+  CommandGroupExecution,
+  CommandGroupOptions,
+  CompletedCommand,
+  RefusedCommand,
+} from './core/index.ts';
 export { command, commands } from './shell/check.ts';
+export { executeCommand } from './shell/spawn.ts';

--- a/packages/redproof/src/command/shell/check.ts
+++ b/packages/redproof/src/command/shell/check.ts
@@ -32,7 +32,6 @@ export function command<const R extends RuleRef>(options: CommandCheckOptions<R>
 
   const policy = exitPolicy(options.exitCodes);
   const label = labelOf(options);
-  const maxOutputBytes = options.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES;
 
   return {
     description: commandDescription(options),
@@ -46,7 +45,15 @@ export function command<const R extends RuleRef>(options: CommandCheckOptions<R>
         return cwdOutsideRoot(commandScan(label, startedAt, now(), 1), label, cwd);
       }
 
-      const execution = await executeCommand(options, cwd, maxOutputBytes);
+      const execution = await executeCommand({
+        command: options.command,
+        cwd,
+        ...(options.args ? { args: options.args } : {}),
+        ...(options.label === undefined ? {} : { label: options.label }),
+        ...(options.env ? { env: options.env } : {}),
+        ...(options.timeoutMs ? { timeoutMs: options.timeoutMs } : {}),
+        maxOutputBytes: options.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES,
+      });
       return commandResult(options.rule, label, policy, execution, commandScan(label, startedAt, now(), 1));
     },
   };

--- a/packages/redproof/src/command/shell/process-tree.ts
+++ b/packages/redproof/src/command/shell/process-tree.ts
@@ -15,13 +15,14 @@ function signalGroup(child: ChildProcess, signal: NodeJS.Signals): void {
 
   try {
     process.kill(-child.pid, signal);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== 'ESRCH') child.kill(signal);
+  } catch {
+    child.kill(signal);
   }
 }
 
 function groupIsAlive(child: ChildProcess): boolean {
   if (child.pid === undefined) return false;
+  if (child.exitCode === null && child.signalCode === null) return true;
   try {
     process.kill(-child.pid, 0);
     return true;
@@ -58,8 +59,52 @@ async function terminateWindowsTree(child: ChildProcess): Promise<void> {
       child.kill('SIGKILL');
       resolve();
     });
-    killer.once('close', () => resolve());
+    killer.once('close', code => {
+      if (code !== 0) child.kill('SIGKILL');
+      resolve();
+    });
   });
+}
+
+const FORWARDED_SIGNALS: readonly NodeJS.Signals[] = ['SIGINT', 'SIGTERM', 'SIGHUP'];
+const liveChildren = new Set<ChildProcess>();
+let forwarding = false;
+
+function forwardSignal(signal: NodeJS.Signals): void {
+  for (const child of liveChildren) signalGroup(child, signal);
+  stopForwarding();
+  if (process.listenerCount(signal) === 0) process.kill(process.pid, signal);
+}
+
+function killLiveGroups(): void {
+  for (const child of liveChildren) signalGroup(child, 'SIGKILL');
+}
+
+function startForwarding(): void {
+  if (forwarding) return;
+  forwarding = true;
+  for (const signal of FORWARDED_SIGNALS) process.on(signal, forwardSignal);
+  process.on('exit', killLiveGroups);
+}
+
+function stopForwarding(): void {
+  if (!forwarding) return;
+  forwarding = false;
+  for (const signal of FORWARDED_SIGNALS) process.removeListener(signal, forwardSignal);
+  process.removeListener('exit', killLiveGroups);
+}
+
+/** A detached child has its own session, so parent signals and parent exit must be forwarded to its group. */
+export function superviseProcessTree(child: ChildProcess): void {
+  if (process.platform === 'win32') return;
+  liveChildren.add(child);
+  const release = (): void => {
+    liveChildren.delete(child);
+    if (liveChildren.size === 0) stopForwarding();
+  };
+  child.once('exit', release);
+  child.once('error', release);
+  startForwarding();
 }
 
 /** Stop the complete process tree before a refused execution can return. */

--- a/packages/redproof/src/command/shell/process-tree.ts
+++ b/packages/redproof/src/command/shell/process-tree.ts
@@ -1,0 +1,69 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+
+const FORCE_KILL_AFTER_MS = 250;
+const POLL_MS = 10;
+
+function pause(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function signalGroup(child: ChildProcess, signal: NodeJS.Signals): void {
+  if (child.pid === undefined) {
+    child.kill(signal);
+    return;
+  }
+
+  try {
+    process.kill(-child.pid, signal);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ESRCH') child.kill(signal);
+  }
+}
+
+function groupIsAlive(child: ChildProcess): boolean {
+  if (child.pid === undefined) return false;
+  try {
+    process.kill(-child.pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForGroupExit(child: ChildProcess, durationMs: number): Promise<boolean> {
+  const deadline = Date.now() + durationMs;
+  while (groupIsAlive(child) && Date.now() < deadline) await pause(POLL_MS);
+  return !groupIsAlive(child);
+}
+
+async function terminatePosixTree(child: ChildProcess): Promise<void> {
+  signalGroup(child, 'SIGTERM');
+  if (await waitForGroupExit(child, FORCE_KILL_AFTER_MS)) return;
+  signalGroup(child, 'SIGKILL');
+  await waitForGroupExit(child, FORCE_KILL_AFTER_MS);
+}
+
+async function terminateWindowsTree(child: ChildProcess): Promise<void> {
+  if (child.pid === undefined) {
+    child.kill('SIGKILL');
+    return;
+  }
+
+  await new Promise<void>(resolve => {
+    const killer = spawn('taskkill', ['/pid', String(child.pid), '/t', '/f'], {
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+    killer.once('error', () => {
+      child.kill('SIGKILL');
+      resolve();
+    });
+    killer.once('close', () => resolve());
+  });
+}
+
+/** Stop the complete process tree before a refused execution can return. */
+export async function terminateProcessTree(child: ChildProcess): Promise<void> {
+  if (process.platform === 'win32') return terminateWindowsTree(child);
+  return terminatePosixTree(child);
+}

--- a/packages/redproof/src/command/shell/spawn.ts
+++ b/packages/redproof/src/command/shell/spawn.ts
@@ -1,23 +1,25 @@
 import { spawn } from 'node:child_process';
-import type { RuleRef } from '../../domain/index.ts';
-import type { CommandCheckOptions } from '../core/options.ts';
+import {
+  DEFAULT_MAX_OUTPUT_BYTES,
+  validateCommandExecutionOptions,
+  type CommandExecutionOptions,
+} from '../core/options.ts';
 import { outputDetail, type CommandExecution } from '../core/outcome.ts';
+import { terminateProcessTree } from './process-tree.ts';
 
-const FORCE_KILL_AFTER_MS = 250;
+export function executeCommand(options: CommandExecutionOptions): Promise<CommandExecution> {
+  validateCommandExecutionOptions(options);
+  const maxOutputBytes = options.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES;
 
-export function executeCommand(
-  options: CommandCheckOptions<RuleRef>,
-  cwd: string,
-  maxOutputBytes: number,
-): Promise<CommandExecution> {
   return new Promise(resolveExecution => {
     let child: ReturnType<typeof spawn>;
     try {
       child = spawn(options.command, options.args ?? [], {
-        cwd,
+        cwd: options.cwd,
         env: { ...process.env, ...options.env },
         shell: false,
         stdio: ['ignore', 'pipe', 'pipe'],
+        detached: process.platform !== 'win32',
       });
     } catch (error) {
       resolveExecution({
@@ -35,7 +37,7 @@ export function executeCommand(
     let settled = false;
     let interruption: 'timeout' | 'output-limit' | undefined;
     let timeout: NodeJS.Timeout | undefined;
-    let forceKill: NodeJS.Timeout | undefined;
+    let termination: Promise<void> | undefined;
 
     const captured = () => ({
       stdout: Buffer.concat(stdout).toString('utf8'),
@@ -46,16 +48,13 @@ export function executeCommand(
       if (settled) return;
       settled = true;
       if (timeout) clearTimeout(timeout);
-      if (forceKill) clearTimeout(forceKill);
       resolveExecution(outcome);
     };
 
     const interrupt = (reason: 'timeout' | 'output-limit'): void => {
       if (interruption) return;
       interruption = reason;
-      child.kill();
-      forceKill = setTimeout(() => child.kill('SIGKILL'), FORCE_KILL_AFTER_MS);
-      forceKill.unref();
+      termination = terminateProcessTree(child);
     };
 
     const capture = (target: Buffer[], chunk: Buffer | string): void => {
@@ -80,8 +79,9 @@ export function executeCommand(
       });
     });
 
-    child.once('close', (code, signal) => {
+    child.once('close', async (code, signal) => {
       const output = captured();
+      if (interruption || signal) await (termination ??= terminateProcessTree(child));
       if (interruption === 'timeout') {
         const detail = outputDetail(output.stdout, output.stderr);
         settle({

--- a/packages/redproof/src/command/shell/spawn.ts
+++ b/packages/redproof/src/command/shell/spawn.ts
@@ -5,7 +5,7 @@ import {
   type CommandExecutionOptions,
 } from '../core/options.ts';
 import { outputDetail, type CommandExecution } from '../core/outcome.ts';
-import { terminateProcessTree } from './process-tree.ts';
+import { superviseProcessTree, terminateProcessTree } from './process-tree.ts';
 
 export function executeCommand(options: CommandExecutionOptions): Promise<CommandExecution> {
   validateCommandExecutionOptions(options);
@@ -30,6 +30,7 @@ export function executeCommand(options: CommandExecutionOptions): Promise<Comman
       });
       return;
     }
+    superviseProcessTree(child);
 
     const stdout: Buffer[] = [];
     const stderr: Buffer[] = [];

--- a/scripts/verify-package.ts
+++ b/scripts/verify-package.ts
@@ -152,9 +152,10 @@ try {
 
   await writeFile(
     join(consumer, 'probe-command.mjs'),
-    "import { command, commands } from 'redproof/command';\n"
+    "import { command, commands, executeCommand } from 'redproof/command';\n"
     + "if (typeof command !== 'function') throw new Error('missing command export');\n"
-    + "if (typeof commands !== 'function') throw new Error('missing commands export');\n",
+    + "if (typeof commands !== 'function') throw new Error('missing commands export');\n"
+    + "if (typeof executeCommand !== 'function') throw new Error('missing executeCommand export');\n",
   );
   const commandImport = tryRun('node', ['probe-command.mjs'], consumer);
   report(commandImport.ok, 'redproof/command imports at run time', commandImport.ok ? '' : commandImport.output.slice(0, 300));
@@ -234,12 +235,13 @@ try {
   const tsc = join(REPO, 'node_modules', '.bin', 'tsc');
 
   const green = "import { defineGate, defineRule } from 'redproof';\n"
-    + "import { command, commands } from 'redproof/command';\n"
+    + "import { command, commands, executeCommand } from 'redproof/command';\n"
     + "import { stryker } from '@redproof/stryker';\n"
     + "import { vitest } from '@redproof/testing';\n"
     + "const rule = defineRule({ id: 'consumer/command', description: 'command succeeds' });\n"
     + "export const check = command({ rule, command: 'node' });\n"
     + "export const group = commands({ entries: [{ rule, command: 'node' }] });\n"
+    + "export const execution = executeCommand({ command: 'node', cwd: '/project', timeoutMs: 1_000 });\n"
     + "export const mutation = stryker({ cwd: 'packages/parser', rules: { noNewUndetectedMutants: { acceptedMutantsFile: 'accepted-mutants.json' } } });\n"
     + "export const tests = vitest({ cwd: 'packages/parser', reportFile: 'results.json', rules: { testsPass: true, noFlakyTests: true } });\n"
     + "export const gate = defineGate;\n";

--- a/tests/command.test.ts
+++ b/tests/command.test.ts
@@ -1,4 +1,6 @@
 import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import { mkdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import test from 'node:test';
@@ -102,23 +104,85 @@ test('command refuses when execution exceeds its timeout', async () => {
   assert.equal(checkResult.why.code, 'command-timeout');
 });
 
-test('command timeout terminates descendants before they can outlive the Check', async () => {
-  await withWorkspace(async root => {
-    const descendant = "require('node:fs').writeFileSync('descendant-started.txt', ''); process.on('SIGTERM', () => {}); setTimeout(() => require('node:fs').writeFileSync('escaped.txt', 'alive'), 1_600); setInterval(() => {}, 1_000)";
-    const parent = `require('node:child_process').spawn(process.execPath, ['-e', ${JSON.stringify(descendant)}], { stdio: 'ignore' }); setInterval(() => {}, 1_000)`;
-    const checkResult = await command({
-      rule,
-      command: process.execPath,
-      args: ['-e', parent],
-      timeoutMs: 1_000,
-    }).run({ root, rules: [rule.id] });
+function processAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
-    assert.equal(checkResult.verdict, 'refuse');
-    if (checkResult.verdict !== 'refuse') return;
-    assert.equal(checkResult.why.code, 'command-timeout');
-    assert.equal(await readFile(join(root, 'descendant-started.txt'), 'utf8'), '');
-    await delay(500);
-    await assert.rejects(readFile(join(root, 'escaped.txt')));
+async function eventually(condition: () => boolean, withinMs: number): Promise<boolean> {
+  const deadline = Date.now() + withinMs;
+  while (!condition() && Date.now() < deadline) await delay(20);
+  return condition();
+}
+
+async function pidFrom(file: string): Promise<number> {
+  const found = await eventually(() => {
+    try { return Number(readFileSync(file, 'utf8')) > 0; } catch { return false; }
+  }, 5_000);
+  if (!found) throw new Error(`${file} was never written`);
+  return Number(await readFile(file, 'utf8'));
+}
+
+function killQuietly(pid: number | undefined): void {
+  if (pid === undefined) return;
+  try { process.kill(pid, 'SIGKILL'); } catch {}
+}
+
+function stubbornDescendant(pidFile: string): string {
+  return `require('node:fs').writeFileSync(${JSON.stringify(pidFile)}, String(process.pid)); process.on('SIGTERM', () => {}); setTimeout(() => {}, 10_000)`;
+}
+
+function parentOf(descendant: string, pidFile?: string): string {
+  const record = pidFile ? `require('node:fs').writeFileSync(${JSON.stringify(pidFile)}, String(process.pid)); ` : '';
+  return `${record}require('node:child_process').spawn(process.execPath, ['-e', ${JSON.stringify(descendant)}], { stdio: 'ignore' }); setTimeout(() => {}, 10_000)`;
+}
+
+test('command timeout terminates a SIGTERM-resistant descendant before the Check returns', async () => {
+  await withWorkspace(async root => {
+    const pidFile = join(root, 'descendant.pid');
+    let descendant: number | undefined;
+    try {
+      const checkResult = await command({
+        rule,
+        command: process.execPath,
+        args: ['-e', parentOf(stubbornDescendant(pidFile), undefined)],
+        timeoutMs: 1_000,
+      }).run({ root, rules: [rule.id] });
+
+      assert.equal(checkResult.verdict, 'refuse');
+      if (checkResult.verdict !== 'refuse') return;
+      assert.equal(checkResult.why.code, 'command-timeout');
+      descendant = await pidFrom(pidFile);
+      assert.equal(await eventually(() => !processAlive(descendant!), 500), true, 'the descendant outlived the Check');
+    } finally {
+      killQuietly(descendant);
+    }
+  });
+});
+
+test('a parent SIGINT reaches a supervised command and its descendants', async () => {
+  await withWorkspace(async root => {
+    const childPidFile = join(root, 'child.pid');
+    const descendantPidFile = join(root, 'descendant.pid');
+    const child = parentOf(stubbornDescendant(descendantPidFile), childPidFile);
+    const host = `import { executeCommand } from 'redproof/command'; await executeCommand({ command: process.execPath, args: ['-e', ${JSON.stringify(child)}], cwd: ${JSON.stringify(root)} });`;
+    const hostProcess = spawn(process.execPath, ['--input-type=module', '-e', host], { cwd: process.cwd(), stdio: 'ignore', detached: true });
+    const hostExit = new Promise<NodeJS.Signals | null>(resolve => hostProcess.once('exit', (_, signal) => resolve(signal)));
+    let pids: number[] = [];
+    try {
+      pids = [await pidFrom(childPidFile), await pidFrom(descendantPidFile)];
+      process.kill(-hostProcess.pid!, 'SIGINT');
+
+      assert.equal(await hostExit, 'SIGINT');
+      assert.equal(await eventually(() => pids.every(pid => !processAlive(pid)), 1_000), true, 'a command outlived its interrupted host');
+    } finally {
+      for (const pid of pids) killQuietly(pid);
+      killQuietly(hostProcess.pid);
+    }
   });
 });
 

--- a/tests/command.test.ts
+++ b/tests/command.test.ts
@@ -2,7 +2,8 @@ import assert from 'node:assert/strict';
 import { mkdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import test from 'node:test';
-import { command, commands, type CommandCheckOptions } from 'redproof/command';
+import { setTimeout as delay } from 'node:timers/promises';
+import { command, commands, executeCommand, type CommandCheckOptions } from 'redproof/command';
 import { defineRule } from 'redproof';
 import { withWorkspace } from './helpers/workspace.ts';
 
@@ -26,6 +27,30 @@ async function runNode(
     ...options,
   }).run({ root, rules: [rule.id] }));
 }
+
+test('executeCommand exposes supervised execution without applying Gate policy', async () => {
+  await withWorkspace(async root => {
+    const execution = await executeCommand({
+      command: process.execPath,
+      args: ['-e', "process.stdout.write('structured'); process.exit(3)"],
+      cwd: root,
+    });
+
+    assert.deepEqual(execution, {
+      kind: 'completed',
+      exitCode: 3,
+      stdout: 'structured',
+      stderr: '',
+    });
+  });
+});
+
+test('executeCommand requires its adapter caller to supply an absolute working directory', () => {
+  assert.throws(
+    () => executeCommand({ command: process.execPath, cwd: '.' }),
+    /executeCommand cwd must be absolute/,
+  );
+});
 
 test('command maps exit zero to PASS without forwarding captured output', async () => {
   const checkResult = await runNode("process.stdout.write('captured output')");
@@ -75,6 +100,26 @@ test('command refuses when execution exceeds its timeout', async () => {
   assert.equal(checkResult.verdict, 'refuse');
   if (checkResult.verdict !== 'refuse') return;
   assert.equal(checkResult.why.code, 'command-timeout');
+});
+
+test('command timeout terminates descendants before they can outlive the Check', async () => {
+  await withWorkspace(async root => {
+    const descendant = "require('node:fs').writeFileSync('descendant-started.txt', ''); process.on('SIGTERM', () => {}); setTimeout(() => require('node:fs').writeFileSync('escaped.txt', 'alive'), 1_600); setInterval(() => {}, 1_000)";
+    const parent = `require('node:child_process').spawn(process.execPath, ['-e', ${JSON.stringify(descendant)}], { stdio: 'ignore' }); setInterval(() => {}, 1_000)`;
+    const checkResult = await command({
+      rule,
+      command: process.execPath,
+      args: ['-e', parent],
+      timeoutMs: 1_000,
+    }).run({ root, rules: [rule.id] });
+
+    assert.equal(checkResult.verdict, 'refuse');
+    if (checkResult.verdict !== 'refuse') return;
+    assert.equal(checkResult.why.code, 'command-timeout');
+    assert.equal(await readFile(join(root, 'descendant-started.txt'), 'utf8'), '');
+    await delay(500);
+    await assert.rejects(readFile(join(root, 'escaped.txt')));
+  });
 });
 
 test('command refuses when execution is terminated by a signal', async () => {

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -1,7 +1,7 @@
 import { testing, vitest, report, runner } from '@redproof/testing';
 import { dependencyCruiser } from '@redproof/dependency-cruiser';
 import { stryker } from '@redproof/stryker';
-import { command, commands } from 'redproof/command';
+import { command, commands, executeCommand, type CommandExecutionOptions } from 'redproof/command';
 import {
   counting,
   defineAdapter,
@@ -38,6 +38,13 @@ const scan: Scan = {
   finishedAt: '',
   inspected: 1,
 };
+
+const executionOptions: CommandExecutionOptions = {
+  command: 'node',
+  cwd: '/project',
+  timeoutMs: 1_000,
+};
+void executeCommand(executionOptions);
 
 const R1 = defineRule({ id: 'r1', description: 'R1' });
 const R2 = defineRule({ id: 'r2', description: 'R2' });


### PR DESCRIPTION
## Summary

- add a reusable executeCommand process supervisor under redproof/command
- terminate complete POSIX and Windows child-process trees on timeout, output overflow, and signal interruption
- keep Gate cwd confinement and exit-code verdict policy in the command Check
- add a causal regression with a SIGTERM-resistant descendant, plus docs, types, and package probes

## Verification

- npm run check (240/240 native tests; 4/4 self-Gates; 22/22 Rules; all self-proofs)
- npm run verify:package
- npm run docs:typecheck

## Compatibility

The existing command Check semantics are unchanged. executeCommand is an additive low-level API for adapters that need supervised process evidence without adopting command Rule policy.

Written by an AI agent on behalf of @schalermthai; it has not yet been reviewed by a human.