### PR TITLE
Release the output pipes after a tree kill and keep a signal's refusal code

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -36,8 +36,9 @@ Child output is captured for diagnostics. It is never inherited by reporter
 output, so a machine-readable report stays clean. Each command runs in its own
 process group with no terminal, so it cannot prompt. A timeout or output
 overflow stops that group before the Check returns. A process that starts its
-own session is outside the group. Bad options throw at once, before any process
-starts.
+own session is outside the group. Such a process can keep the output pipes
+open, so the Check releases them after a timeout or a signal instead of
+waiting for it. Bad options throw at once, before any process starts.
 
 ## Exit codes decide the verdict
 

--- a/packages/redproof/src/command/shell/spawn.ts
+++ b/packages/redproof/src/command/shell/spawn.ts
@@ -52,10 +52,17 @@ export function executeCommand(options: CommandExecutionOptions): Promise<Comman
       resolveExecution(outcome);
     };
 
+    const releasePipes = (): void => {
+      child.stdout?.destroy();
+      child.stderr?.destroy();
+    };
+
+    const terminate = (): Promise<void> => terminateProcessTree(child).then(releasePipes);
+
     const interrupt = (reason: 'timeout' | 'output-limit'): void => {
-      if (interruption) return;
+      if (interruption || termination) return;
       interruption = reason;
-      termination = terminateProcessTree(child);
+      termination = terminate();
     };
 
     const capture = (target: Buffer[], chunk: Buffer | string): void => {
@@ -80,9 +87,13 @@ export function executeCommand(options: CommandExecutionOptions): Promise<Comman
       });
     });
 
+    child.once('exit', (_, signal) => {
+      if (signal && !interruption) termination ??= terminate();
+    });
+
     child.once('close', async (code, signal) => {
       const output = captured();
-      if (interruption || signal) await (termination ??= terminateProcessTree(child));
+      if (interruption || signal) await (termination ??= terminate());
       if (interruption === 'timeout') {
         const detail = outputDetail(output.stdout, output.stderr);
         settle({

--- a/tests/command.test.ts
+++ b/tests/command.test.ts
@@ -133,7 +133,7 @@ function killQuietly(pid: number | undefined): void {
 }
 
 function stubbornDescendant(pidFile: string): string {
-  return `require('node:fs').writeFileSync(${JSON.stringify(pidFile)}, String(process.pid)); process.on('SIGTERM', () => {}); setTimeout(() => {}, 10_000)`;
+  return `process.on('SIGTERM', () => {}); require('node:fs').writeFileSync(${JSON.stringify(pidFile)}, String(process.pid)); setTimeout(() => {}, 10_000)`;
 }
 
 function parentOf(descendant: string, pidFile?: string): string {
@@ -182,6 +182,93 @@ test('a parent SIGINT reaches a supervised command and its descendants', async (
     } finally {
       for (const pid of pids) killQuietly(pid);
       killQuietly(hostProcess.pid);
+    }
+  });
+});
+
+async function pidIfWritten(file: string): Promise<number | undefined> {
+  const found = await eventually(() => {
+    try { return Number(readFileSync(file, 'utf8')) > 0; } catch { return false; }
+  }, 1_000);
+  return found ? Number(await readFile(file, 'utf8')) : undefined;
+}
+
+function pipeHoldingDescendant(pidFile: string): string {
+  return `require('node:fs').writeFileSync(${JSON.stringify(pidFile)}, String(process.pid)); setTimeout(() => {}, 10_000)`;
+}
+
+/** Spawn the descendant, wait until it has written its pid, then run `thenDo`. */
+function parentWaitingFor(descendant: string, pidFile: string, stdio: string, thenDo: string): string {
+  return `require('node:child_process').spawn(process.execPath, ['-e', ${JSON.stringify(descendant)}], { stdio: '${stdio}', detached: ${stdio === 'inherit'} }).unref(); const tick = () => { if (require('node:fs').existsSync(${JSON.stringify(pidFile)})) { ${thenDo} } else setTimeout(tick, 5); }; tick();`;
+}
+
+test('a timeout resolves even when a detached descendant keeps the output pipes', async () => {
+  await withWorkspace(async root => {
+    const pidFile = join(root, 'holder.pid');
+    let holder: number | undefined;
+    try {
+      const started = Date.now();
+      const checkResult = await command({
+        rule,
+        command: process.execPath,
+        args: ['-e', parentWaitingFor(pipeHoldingDescendant(pidFile), pidFile, 'inherit', 'process.exit(0)')],
+        timeoutMs: 3_000,
+      }).run({ root, rules: [rule.id] });
+      holder = await pidIfWritten(pidFile);
+
+      assert.equal(checkResult.verdict, 'refuse');
+      if (checkResult.verdict !== 'refuse') return;
+      assert.equal(checkResult.why.code, 'command-timeout');
+      assert.ok(Date.now() - started < 6_000, 'the Check waited for the descendant instead of the timeout');
+    } finally {
+      killQuietly(holder);
+    }
+  });
+});
+
+test('a signalled command resolves without a timeout when a detached descendant keeps the output pipes', async () => {
+  await withWorkspace(async root => {
+    const pidFile = join(root, 'holder.pid');
+    let holder: number | undefined;
+    try {
+      const started = Date.now();
+      const checkResult = await command({
+        rule,
+        command: process.execPath,
+        args: ['-e', parentWaitingFor(pipeHoldingDescendant(pidFile), pidFile, 'inherit', "process.kill(process.pid, 'SIGTERM')")],
+      }).run({ root, rules: [rule.id] });
+      holder = await pidIfWritten(pidFile);
+
+      assert.equal(checkResult.verdict, 'refuse');
+      if (checkResult.verdict !== 'refuse') return;
+      assert.equal(checkResult.why.code, 'command-signaled');
+      assert.ok(Date.now() - started < 6_000, 'the Check waited for the descendant instead of the signal');
+    } finally {
+      killQuietly(holder);
+    }
+  });
+});
+
+test('a signal that arrives before the timeout keeps its own refusal code', async () => {
+  await withWorkspace(async root => {
+    const pidFile = join(root, 'descendant.pid');
+    let descendant: number | undefined;
+    try {
+      const timeoutMs = 5_000;
+      const signalAt = Date.now() + timeoutMs - 150;
+      const checkResult = await command({
+        rule,
+        command: process.execPath,
+        args: ['-e', parentWaitingFor(stubbornDescendant(pidFile), pidFile, 'ignore', `if (Date.now() >= ${signalAt}) process.kill(process.pid, 'SIGTERM'); else setTimeout(tick, 5);`)],
+        timeoutMs,
+      }).run({ root, rules: [rule.id] });
+      descendant = await pidIfWritten(pidFile);
+
+      assert.equal(checkResult.verdict, 'refuse');
+      if (checkResult.verdict !== 'refuse') return;
+      assert.equal(checkResult.why.code, 'command-signaled');
+    } finally {
+      killQuietly(descendant);
     }
   });
 });


### PR DESCRIPTION
## Problem

Two gaps remained in `executeCommand` after #59. A descendant that starts its own session and keeps the inherited stdout or stderr pipe blocks the `close` event, so a timed-out or signalled Check waits for that descendant instead of returning. And when a child exits by signal while its descendants are cleaned up, a timeout that fires inside that window relabels the refusal from `command-signaled` to `command-timeout`.

The review found a third gap. A command that exits normally while such a descendant holds the pipes hangs forever with no `timeoutMs`. With a `timeoutMs` it is refused as `command-timeout` although the exit code is known.

## Fix

After the process group is terminated, the Check destroys both output pipes, so `close` fires without the descendant. A child that exits by signal starts that termination at once. A timeout that fires once termination has started is ignored, so the first cause keeps its code.

After a normal exit the Check waits 250 ms for the pipes to close. If they stay open, it stops what is left of the group, releases the pipes, and settles with the real exit code. A prompt close never touches the group, so a worker the command leaves alive with its own stdio is not killed. Pipes are released even when the tree kill rejects, and an `error` raised during termination is ignored. One sentence in `docs/commands.md` describes the behaviour.

## Verification

- `tests/command.test.ts`: 27 of 27 pass in about 15 s.
- Red-proof, pipe release removed: the three pipe-holding descendant tests fail after about 10 s each with "the Check waited for the descendant". Restored: 27 of 27.
- Red-proof, timeout no longer ignored after termination: the signal-before-timeout test fails with `command-timeout`. Restored: green.
- Red-proof, grace termination removed: the normal-exit test fails after about 10 s with "the Check waited for the descendant instead of the exit". Restored: green.
- Red-proof, `terminateProcessTree` made to reject: with a single `then` handler all four tests crash with an unhandled rejection; with the rejection handler the exited-child tests still resolve.
- Probe: a command that exits 0 and leaves a SIGTERM-ignoring worker with its own stdio completes in 663 ms and the worker is still alive.
- `npm run check` on the integration branch with all fixes: 258 of 258 tests, all self-proofs established.