### PR TITLE
Keep Vite's temporary config bundle out of the Gate copy

### DIFF
--- a/docs/built-in-adapters.md
+++ b/docs/built-in-adapters.md
@@ -89,6 +89,13 @@ Redproof passes `--no-cache` to Vitest. Without it, Vitest writes a results
 cache under `node_modules/.vite` inside the project, and a proof run refuses
 with `workspace-not-restored`. The adapter is proven against Vitest 5.
 
+Vite's default config loader has the same effect. It writes a temporary bundle
+of the config file under the nearest `node_modules/.vite-temp` and leaves that
+directory behind. When a `node_modules` directory sits inside the Gate root, as
+in a pnpm workspace, a proof run refuses with `workspace-not-restored`. Pass
+`args: ['--configLoader', 'runner']` to load the config without that bundle.
+The flag needs Vitest 3.1 or later, and Vitest marks the loader experimental.
+
 The testing integration can expose these Rules, depending on the selected report format:
 
 - `testing/tests-pass`

--- a/fixtures/testing-vitest/gates/tests.ts
+++ b/fixtures/testing-vitest/gates/tests.ts
@@ -5,6 +5,7 @@ const adapter = vitest({
   cwd: 'project',
   configFile: 'vitest.config.js',
   reportFile: 'reports/results.json',
+  args: ['--configLoader', 'runner'],
   rules: {
     testsPass: true,
     noFlakyTests: true,

--- a/tests/adapters/integration.test.ts
+++ b/tests/adapters/integration.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { lstat } from 'node:fs/promises';
+import { lstat, mkdir, rm } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import test from 'node:test';
 import { checkProject, proofEstablished, proveProject } from 'redproof';
@@ -62,6 +62,20 @@ test('Vitest adapter cleans a nested project report while proving test policies'
     ],
   );
   await assertMissing(reports);
+});
+
+test('Vitest proofs restore a workspace that has a nested node_modules directory', async () => {
+  const nested = resolve('fixtures/testing-vitest/project/node_modules');
+  await mkdir(nested, { recursive: true });
+  try {
+    const proof = await proveProject(configOf('testing-vitest'));
+    assert.deepEqual(
+      proof.outcomes.map(outcome => [outcome.status, proofEstablished(outcome)]),
+      Array.from({ length: 6 }, () => ['completed', true]),
+    );
+  } finally {
+    await rm(nested, { recursive: true, force: true });
+  }
 });
 
 test('Stryker adapter passes strong tests and proves strict, baseline, score, and refusal policies', async () => {


### PR DESCRIPTION
## Problem

Vite's default config loader writes a temporary bundle of the config file under the nearest `node_modules/.vite-temp` and leaves that directory behind. The walk starts at the config file's directory, and an empty `node_modules` directory qualifies. When a `node_modules` directory sits inside the Gate root, as in a pnpm workspace, copies-mode `prove` refuses the first proof with `workspace-not-restored` and skips the rest. The repo fixture could not show this because its nearest `node_modules` is the repository root, outside the Gate root. #60 added `--configLoader runner` to the fixture without a comment, a doc line, or a test, and the review removed it.

## Fix

The Vitest fixture passes `args: ['--configLoader', 'runner']` again. `docs/built-in-adapters.md` explains the flag next to the `--no-cache` paragraph, including the Vitest 3.1 requirement. A new integration test creates `fixtures/testing-vitest/project/node_modules` before `proveProject`, expects all 6 proofs to complete, and removes the directory afterwards only when the test created it. The flag stays a fixture setting, not an adapter default, because older Vitest versions reject it.

## Verification

- With the flag: the nested-node_modules test passes. The other Vitest integration test passes with or without the flag, which is why the fixture alone could not catch the problem.
- Red-proof, flag line deleted: the test fails with the first proof `unrestored`. Restored: passes again.
- `--configLoader` is absent from vitest 3.0.9 and present from 3.1.0. Vitest's help marks `runner` experimental and requires Vite 6.1.0 or later.
- `mkdir` with `recursive: true` returns `undefined` for an existing directory on Node 24, so a pre-existing directory survives the test.
- The fixture tree is unchanged after each run.