### PR TITLE
Fix command lifecycle races

### DIFF
--- a/packages/redproof/src/command/shell/process-tree.ts
+++ b/packages/redproof/src/command/shell/process-tree.ts
@@ -94,17 +94,19 @@ function stopForwarding(): void {
   process.removeListener('exit', killLiveGroups);
 }
 
-/** A detached child has its own session, so parent signals and parent exit must be forwarded to its group. */
-export function superviseProcessTree(child: ChildProcess): void {
-  if (process.platform === 'win32') return;
+/** Supervise a detached child's group until the caller finishes all process and pipe cleanup. */
+export function superviseProcessTree(child: ChildProcess): () => void {
+  if (process.platform === 'win32') return () => {};
   liveChildren.add(child);
+  let released = false;
   const release = (): void => {
+    if (released) return;
+    released = true;
     liveChildren.delete(child);
     if (liveChildren.size === 0) stopForwarding();
   };
-  child.once('exit', release);
-  child.once('error', release);
   startForwarding();
+  return release;
 }
 
 /** Stop the complete process tree before a refused execution can return. */

--- a/packages/redproof/src/command/shell/spawn.ts
+++ b/packages/redproof/src/command/shell/spawn.ts
@@ -8,7 +8,7 @@ import { outputDetail, type CommandExecution } from '../core/outcome.ts';
 import { superviseProcessTree, terminateProcessTree } from './process-tree.ts';
 
 /** After a normal exit, how long the pipes may stay open before the rest of the group is stopped. */
-const PIPE_RELEASE_GRACE_MS = 250;
+export const PIPE_RELEASE_GRACE_MS = 250;
 
 export function executeCommand(options: CommandExecutionOptions): Promise<CommandExecution> {
   validateCommandExecutionOptions(options);

--- a/packages/redproof/src/command/shell/spawn.ts
+++ b/packages/redproof/src/command/shell/spawn.ts
@@ -33,7 +33,7 @@ export function executeCommand(options: CommandExecutionOptions): Promise<Comman
       });
       return;
     }
-    superviseProcessTree(child);
+    const releaseProcessTree = superviseProcessTree(child);
 
     const stdout: Buffer[] = [];
     const stderr: Buffer[] = [];
@@ -48,10 +48,16 @@ export function executeCommand(options: CommandExecutionOptions): Promise<Comman
       stderr: Buffer.concat(stderr).toString('utf8'),
     });
 
+    const clearExecutionTimeout = (): void => {
+      if (timeout) clearTimeout(timeout);
+      timeout = undefined;
+    };
+
     const settle = (outcome: CommandExecution): void => {
       if (settled) return;
       settled = true;
-      if (timeout) clearTimeout(timeout);
+      clearExecutionTimeout();
+      releaseProcessTree();
       resolveExecution(outcome);
     };
 
@@ -92,6 +98,7 @@ export function executeCommand(options: CommandExecutionOptions): Promise<Comman
     });
 
     child.once('exit', (_, signal) => {
+      clearExecutionTimeout();
       if (interruption) return;
       if (signal) {
         termination ??= terminate();

--- a/tests/command/command.test.ts
+++ b/tests/command/command.test.ts
@@ -74,8 +74,14 @@ function parentOf(descendant: string, pidFile: string): string {
 }
 
 /** Spawn the descendant, wait until it has written its pid, then run `thenDo`. A detached descendant starts its own session. */
-function parentWaitingFor(descendant: string, pidFile: string, stdio: 'ignore' | 'inherit', thenDo: string): string {
-  return `require('node:child_process').spawn(process.execPath, ['-e', ${JSON.stringify(descendant)}], { stdio: '${stdio}', detached: ${stdio === 'inherit'} }).unref(); const tick = () => { if (require('node:fs').existsSync(${JSON.stringify(pidFile)})) { ${thenDo} } else setTimeout(tick, 5); }; tick();`;
+function parentWaitingFor(
+  descendant: string,
+  pidFile: string,
+  stdio: 'ignore' | 'inherit',
+  thenDo: string,
+  detached = stdio === 'inherit',
+): string {
+  return `require('node:child_process').spawn(process.execPath, ['-e', ${JSON.stringify(descendant)}], { stdio: '${stdio}', detached: ${detached} }).unref(); const tick = () => { if (require('node:fs').existsSync(${JSON.stringify(pidFile)})) { ${thenDo} } else setTimeout(tick, 5); }; tick();`;
 }
 
 test('executeCommand returns the raw exit code and both captured streams without applying Gate policy', async () => {
@@ -310,6 +316,67 @@ test('a normal exit keeps its verdict while a detached descendant still holds th
       assert.equal(processAlive(holder), true, 'the Check waited for the pipe holder instead of the exit');
     } finally {
       killQuietly(holder);
+    }
+  });
+});
+
+test('a direct exit before its deadline is not rewritten as a timeout while the pipes are released', async () => {
+  await withWorkspace(async root => {
+    const pidFile = join(root, 'holder.pid');
+    let holder: number | undefined;
+    try {
+      const timeoutMs = 2_000;
+      const exitAt = Date.now() + timeoutMs - 150;
+      const checkResult = await command({
+        rule,
+        command: process.execPath,
+        args: ['-e', parentWaitingFor(
+          pipeHoldingDescendant(pidFile),
+          pidFile,
+          'inherit',
+          `if (Date.now() >= ${exitAt}) process.exit(0); else setTimeout(tick, 5);`,
+        )],
+        timeoutMs,
+      }).run({ root, rules: [rule.id] });
+      holder = await pidFrom(pidFile);
+
+      assert.equal(checkResult.verdict, 'pass');
+    } finally {
+      killQuietly(holder);
+    }
+  });
+});
+
+test('a parent signal during pipe release still reaches the surviving command group', async () => {
+  await withWorkspace(async root => {
+    const childPidFile = join(root, 'child.pid');
+    const descendantPidFile = join(root, 'descendant.pid');
+    const signalFile = join(root, 'descendant.signal');
+    const descendant = [
+      `process.on('SIGINT', () => { require('node:fs').writeFileSync(${JSON.stringify(signalFile)}, 'SIGINT'); process.exit(0); });`,
+      pipeHoldingDescendant(descendantPidFile),
+    ].join(' ');
+    const child = [
+      `require('node:fs').writeFileSync(${JSON.stringify(childPidFile)}, String(process.pid));`,
+      parentWaitingFor(descendant, descendantPidFile, 'inherit', 'process.exit(0)', false),
+    ].join(' ');
+    const host = `import { executeCommand } from 'redproof/command'; await executeCommand({ command: process.execPath, args: ['-e', ${JSON.stringify(child)}], cwd: ${JSON.stringify(root)} });`;
+    const hostProcess = spawn(process.execPath, ['--input-type=module', '-e', host], { cwd: process.cwd(), stdio: 'ignore', detached: true });
+    const hostExit = new Promise<NodeJS.Signals | null>(resolve => hostProcess.once('exit', (_, signal) => resolve(signal)));
+    let pids: number[] = [];
+    try {
+      pids = [await pidFrom(childPidFile), await pidFrom(descendantPidFile)];
+      assert.equal(await eventually(() => !processAlive(pids[0]!), 1_000), true, 'the direct command never exited');
+      process.kill(-hostProcess.pid!, 'SIGINT');
+
+      assert.equal(await hostExit, 'SIGINT');
+      assert.equal(await eventually(() => {
+        try { return readFileSync(signalFile, 'utf8') === 'SIGINT'; } catch { return false; }
+      }, 1_000), true, 'the descendant never received its host signal');
+      assert.equal(await eventually(() => !processAlive(pids[1]!), 1_000), true, 'the descendant outlived its interrupted host');
+    } finally {
+      for (const pid of pids) killQuietly(pid);
+      killQuietly(hostProcess.pid);
     }
   });
 });

--- a/tests/command/command.test.ts
+++ b/tests/command/command.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 import test from 'node:test';
 import { setTimeout as delay } from 'node:timers/promises';
 import { command, commands, executeCommand, type CommandCheckOptions } from 'redproof/command';
+import { PIPE_RELEASE_GRACE_MS } from '../../packages/redproof/src/command/shell/spawn.ts';
 import { defineRule } from 'redproof';
 import { withWorkspace } from '../helpers/workspace.ts';
 
@@ -326,7 +327,9 @@ test('a direct exit before its deadline is not rewritten as a timeout while the 
     let holder: number | undefined;
     try {
       const timeoutMs = 2_000;
-      const exitAt = Date.now() + timeoutMs - 150;
+      // The deadline must land inside the pipe-release grace, or the bug cannot show.
+      const exitAt = Date.now() + timeoutMs - Math.round(PIPE_RELEASE_GRACE_MS / 2);
+      const started = Date.now();
       const checkResult = await command({
         rule,
         command: process.execPath,
@@ -341,6 +344,8 @@ test('a direct exit before its deadline is not rewritten as a timeout while the 
       holder = await pidFrom(pidFile);
 
       assert.equal(checkResult.verdict, 'pass');
+      assert.ok(Date.now() - started < timeoutMs + 2_000, 'the Check waited for the pipe holder instead of releasing');
+      assert.equal(processAlive(holder), true, 'the Check stopped a holder that was outside its group');
     } finally {
       killQuietly(holder);
     }
@@ -354,6 +359,7 @@ test('a parent signal during pipe release still reaches the surviving command gr
     const signalFile = join(root, 'descendant.signal');
     const descendant = [
       `process.on('SIGINT', () => { require('node:fs').writeFileSync(${JSON.stringify(signalFile)}, 'SIGINT'); process.exit(0); });`,
+      `process.on('SIGTERM', () => { require('node:fs').writeFileSync(${JSON.stringify(signalFile)}, 'SIGTERM'); process.exit(0); });`,
       pipeHoldingDescendant(descendantPidFile),
     ].join(' ');
     const child = [
@@ -367,12 +373,14 @@ test('a parent signal during pipe release still reaches the surviving command gr
     try {
       pids = [await pidFrom(childPidFile), await pidFrom(descendantPidFile)];
       assert.equal(await eventually(() => !processAlive(pids[0]!), 1_000), true, 'the direct command never exited');
+      assert.equal(processAlive(hostProcess.pid!), true, 'the host settled before the pipes were released');
       process.kill(-hostProcess.pid!, 'SIGINT');
 
       assert.equal(await hostExit, 'SIGINT');
       assert.equal(await eventually(() => {
-        try { return readFileSync(signalFile, 'utf8') === 'SIGINT'; } catch { return false; }
-      }, 1_000), true, 'the descendant never received its host signal');
+        try { return readFileSync(signalFile, 'utf8').length > 0; } catch { return false; }
+      }, 1_000), true, 'the descendant received no signal at all');
+      assert.equal(readFileSync(signalFile, 'utf8'), 'SIGINT', 'the descendant was stopped by a group kill, not the host signal');
       assert.equal(await eventually(() => !processAlive(pids[1]!), 1_000), true, 'the descendant outlived its interrupted host');
     } finally {
       for (const pid of pids) killQuietly(pid);


### PR DESCRIPTION
## Problem

The command Check waits 250 ms after a normal exit for the output pipes to close, then stops what is left of the process group. That grace period, added in #62, opened two races.

The execution deadline stayed armed during the grace period. A command that exited successfully just before its `timeoutMs` was relabelled `command-timeout` while the pipes were being released. The refusal message named a timeout for a child that had already exited before the deadline, so the message was false. It also depended on where the deadline landed inside a 250 ms band, so the same command could pass or refuse on timing alone.

The process group also left parent-signal supervision when the direct child exited. If Redproof received SIGINT during pipe cleanup, a surviving same-group descendant could outlive the host.

## Fix

The deadline is cleared as soon as the direct child exits, so pipe cleanup cannot rewrite a decided exit. `superviseProcessTree` no longer registers its own release listeners. It returns an idempotent release function, and the Check calls it when the execution settles, so the group stays supervised through pipe cleanup.

Two causal tests cover the boundaries. The pipe-release grace constant is exported so the deadline test derives its margin from the real value instead of a copied number.

## Verification

- `npm run check` on this branch: exit 0, 552 tests pass, 4 Gates passed, all self-proofs established.
- Red-proof, deadline clear removed: the deadline test fails at 2006 ms. Restored: green.
- Red-proof, supervision released on child exit: the signal test fails with `the descendant never received its host signal`. Restored: green.
- Red-proof, grace termination removed but the deadline clear kept: the deadline test fails with `the Check waited for the pipe holder instead of releasing`. Without the elapsed assertion this partial fix passed in 10 s instead of 2.1 s.
- Red-proof, original bug restored and the grace lowered to 100 ms: the deadline test fails. Without deriving the margin from the exported constant, this combination passed.
- Red-proof, grace set to 0: the signal test fails with `the descendant was stopped by a group kill, not the host signal`.
- Each plant was rebuilt and confirmed present in `dist` before the run. Every plant type-checks. No orphaned child processes remained after any run.

Measured, not fixed: holding supervision until settle means a host exit between the child exit and the settle could stop a group that used to survive. That window measured 0 ms over five runs when no descendant holds the pipes. When one does hold them, the grace timer stops the group anyway, so the end state is the same.