### PR TITLE
Rewrite the Redproof dogfooding showcase

### DIFF
--- a/docs/red-proving-redproof.md
+++ b/docs/red-proving-redproof.md
@@ -1,344 +1,248 @@
-# Red proving Redproof
+# Redproof proves Redproof
 
-Redproof runs Redproof on itself. Five Gates guard this repository. They hold
-27 Rules and 36 Proofs, and they run on every push. This page is not a guide
-to running them. It shows what that looks like, and it makes one point: a Gate
-can guard anything that leaves evidence. A module graph, a purity rule, the
-documentation, and the release inventory are all guarded the same way.
+This repository is not a demonstration project built to make Redproof look
+good. It is one of Redproof's most demanding users.
 
-- [The suite at a glance](#the-suite-at-a-glance)
-- [A Gate spec reads like a promise](#a-gate-spec-reads-like-a-promise)
-- [Gate 1: architecture](#gate-1-architecture)
-- [Gate 2: static-contracts](#gate-2-static-contracts)
-- [How a proof drives tidy-up](#how-a-proof-drives-tidy-up)
-- [Gate 3: test-health](#gate-3-test-health)
-- [Gate 4: adapter-contracts](#gate-4-adapter-contracts)
-- [Gate 5: repository-policy](#gate-5-repository-policy)
-- [What this shows](#what-this-shows)
+Every pull request and every push to `main` asks two separate questions:
 
-## The suite at a glance
+1. Does the repository satisfy its guardrails now?
+2. Can those guardrails still detect the defects they claim to protect us
+   from?
 
-| Gate | The promise | Built from | Rules | Proofs |
-| --- | --- | --- | --- | --- |
-| `architecture` | The structure stays intact. Imports point inward. The core stays pure. | `@redproof/dependency-cruiser` plus a TypeScript AST scan | 12 | 14 |
-| `static-contracts` | The code compiles. Every checked example in the docs compiles. Fragment debt cannot grow. | `redproof/command` with three parallel commands | 3 | 4 |
-| `test-health` | Every test ran and passed. None was skipped. | `@redproof/testing` with a JUnit report | 2 | 3 |
-| `adapter-contracts` | Every built-in Adapter keeps the five documented verdict and evidence contracts. | Five original suites plus five package-owned TCK lanes through `redproof/command` | 5 | 8 |
-| `repository-policy` | A release ships whole. Docs do not link to missing files. | A native Check over a pure policy model | 5 | 7 |
+The first question is familiar. Tests pass, types compile, dependency rules
+hold, and release metadata is consistent. Most quality pipelines stop there.
 
-`npm run self:check` runs the five Gates in isolated copies, in parallel:
+Redproof asks the second question by temporarily introducing a controlled
+defect, running the same Gate, and requiring the expected Rule to breach. A
+green check is useful. A green check whose detection has also been demonstrated
+is much stronger evidence.
 
-```text
- ✓ gates/architecture.ts (12 rules) 7.79s
- ✓ gates/adapter-contracts.ts (5 rules) 1.63s
- ✓ gates/repository-policy.ts (5 rules) 469ms
- ✓ gates/static-contracts.ts (3 rules) 12.52s
- ✓ gates/test-health.ts (2 rules) 44.83s
+Redproof currently protects itself with five Gates, 27 Rules, and 36 proofs.
+These are the controls used by the real CI and release workflows, not a separate
+showcase suite.
 
- Gates      5 passed (5)
- Rules      27 held (27)
-```
+## The dogfooding loop
 
-`npm run self:prove` then breaks each Rule on purpose, one defect at a time,
-and expects the Gate to go red. Every Gate also has a GREEN proof. The
-`repository-policy` Gate has a REFUSE proof as well.
-
-## A Gate spec reads like a promise
-
-A Gate file states what is protected and how each Rule is broken. It holds no
-plumbing. `redproof describe` prints the same file back as a specification.
-This is the `static-contracts` Gate:
+Each Gate owns a promise, the Rules that make the promise precise, and the
+Check that evaluates those Rules. Its proofs exercise that same Check under
+three conditions:
 
 ```text
-Gate: static-contracts
-
-Rules:
-  R1 Workspace source, tests, fixtures, and self-hosted Gates must type-check.
-  R2 Standalone TypeScript examples in the documentation must compile.
-  R3 The number of documentation fragments excluded from compilation must not grow.
-
-Check:
-  run 3 commands: workspace TypeScript, documentation examples, documentation fragment budget
-
-Proof R1:
-  rejects a workspace type error
-  mutation: create tests/redproof-type-proof.ts
-  run the same Check
-  expect Gate FAIL
-
-Proof R2:
-  rejects an invalid checked documentation example
-  mutation: create docs/redproof-doc-example-proof.md
-  run the same Check
-  expect Gate FAIL
-
-Proof R3:
-  rejects growth in unchecked documentation fragments
-  mutation: create docs/redproof-doc-fragment-proof.md
-  run the same Check
-  expect Gate FAIL
-
-Proof GREEN:
-  accepts the current workspace and documentation contracts
-  run the same Check
-  expect Gate PASS
+healthy repository   ──▶ same Gate ──▶ PASS
+controlled defect    ──▶ same Gate ──▶ FAIL the targeted Rule
+unavailable evidence ──▶ same Gate ──▶ REFUSE
 ```
 
-A reviewer can read this without opening the code. Each Rule is a sentence.
-Each Proof names the defect it plants and the verdict it expects. Run
-`npm run self:describe` to print all five Gates.
+A RED proof is not satisfied by any failure. If a proof targets the Rule
+“domain must not import infrastructure” but a different Rule fails, the target
+has not been proven. Redproof reports that distinction instead of treating a
+generically red build as success.
 
-## Gate 1: architecture
+A GREEN proof establishes the healthy baseline. It prevents a permanently
+broken Gate from appearing effective merely because every mutation also fails.
 
-**The promise.** New code cannot quietly break the shape that keeps Redproof
-easy to change. Imports point inward. Contexts talk only through their public
-surface. The pure core never touches a file, a clock, or a process.
+A REFUSE proof establishes honest uncertainty. Missing tools, unreadable
+inputs, timeouts, signals, output overflow, or disallowed empty evidence do not
+become PASS. They also do not become a false product defect. Redproof says that
+the Check could not make a trustworthy decision.
 
-Source: [`gates/architecture.ts`](../gates/architecture.ts).
+Proofs run in isolated project copies. Mutations can create files, remove
+validation, change configuration, break imports, or corrupt evidence
+translation without modifying the developer's working tree. Redproof checks
+that the proof workspace returns to its baseline before it is reused.
 
-### The boundaries
-
-`packages/redproof/src` holds nine contexts side by side: `cli`, `command`,
-`composition`, `inspect`, `project`, `proof`, `reporter`, `run`, and
-`workspace`. Inside a context, code sits in one of three layers.
+The proof report makes the claim and the observed outcome visible together:
 
 ```text
-                     imports point downward only
-
-  entrypoints   index.ts, cli.ts        reach a context only through its index.ts
-       │
-  shell         <context>/shell/**      most of the 23 approved effect boundaries live here
-       │
-  core          <context>/core/**       pure: no fs, process, clock, subprocess, shell
-       │
-  domain        domain/**               types only; depends on nothing above it
-
-  across contexts: <context-a>/** ──▶ <context-b>/index.ts or core/index.ts, never deeper
-  composition may depend only on domain and inspect; every other context is downstream
-  adapters (eslint, testing, ...) ──▶ packages/redproof/src/index.ts only
+✓ architecture / detects a production dependency cycle expected=red actual=fail
+✓ adapter-contracts / refuses when a contract suite floods its output budget expected=refuse actual=refuse
+✓ repository-policy / accepts the current repository contracts expected=green actual=pass
 ```
 
-Nine dependency-cruiser rules draw those lines. Each one is a Redproof Rule,
-and each one has a RED proof that plants the forbidden import:
+## One model for very different guardrails
 
-| Rule | Proof mutation |
-| --- | --- |
-| `no-cycles` | create two domain files that import each other |
-| `core-no-effect-imports` | append `import 'node:fs/promises'` to `run/core/exit-code.ts` |
-| `core-no-shell` | append `import '../shell/worker-process.ts'` to a core file |
-| `domain-inward-only` | make `domain/rule.ts` import `run/core` |
-| `composition-no-runtime-or-reporters` | make `composition/core` import `run/core` |
-| `adapters-public-core-api-only` | make the eslint adapter import a core file directly |
-| `production-no-test-fixture-dependencies` | make a domain file import a fixture |
-| `contexts-import-through-index` | make `run/core` import `proof/core/outcome.ts` directly |
-| `entrypoints-import-through-index` | make `index.ts` export from `proof/shell/runner.ts` |
+Redproof's self-hosted portfolio covers five different kinds of evidence. The
+value is not the number of Gates; it is that the same proof model works across
+all of them.
 
-**How Redproof protects.** A dependency rule that nobody tests is a comment.
-The RED proof shows the rule is live: the planted import breaches exactly the
-Rule that names it. The GREEN proof shows the current tree is clean. When a
-change breaks a boundary, `self:check` names the Rule and the file.
+| Gate | Promise | Evidence | Representative controlled defect |
+| --- | --- | --- | --- |
+| [`architecture`](../gates/architecture.ts) | Dependencies point inward and the functional core remains pure. | dependency-cruiser plus TypeScript syntax analysis | Introduce a dependency cycle, import a shell from the core, or read ambient process state. |
+| [`static-contracts`](../gates/static-contracts.ts) | Source and checked documentation compile, while unchecked fragment debt cannot grow. | TypeScript and documentation commands | Add a type error, an invalid documentation example, or one unbudgeted fragment. |
+| [`test-health`](../gates/test-health.ts) | Every collected test passes and none is skipped. | Structured JUnit evidence through `@redproof/testing` | Add a failing test or a skipped test. |
+| [`adapter-contracts`](../gates/adapter-contracts.ts) | Built-in Adapters validate configuration, handle unavailable execution honestly, preserve pure evidence models, respect report capabilities, and attribute structured findings correctly. | Original contract suites plus package-owned `@redproof/adapter-tck` suites | Remove option validation, corrupt runner mapping, add an effect to a pure model, or drop a selected finding. |
+| [`repository-policy`](../gates/repository-policy.ts) | Every package is complete, aligned, documented, and verified before release. | Package manifests, workflows, source inventory, and documentation links | Omit a package from release automation, diverge a version, remove verification, or add a broken link. |
 
-### Functional core and imperative shell
+Together they protect behavior, architecture, documentation, integrations, and
+the release boundary. Redproof does not require all guardrails to speak the
+same native protocol. Commands, structured reports, dependency graphs, syntax
+trees, and repository metadata are translated into the same PASS, FAIL, and
+REFUSE semantics.
 
-The functional core is `domain/**` and every `*/core/**`. The core receives
-values and returns decisions. It cannot read files, spawn processes, observe
-the clock or the environment, or import a shell module. Three native Rules
-enforce this with a TypeScript AST scan in
-[`gates/checks/effect-boundaries.ts`](../gates/checks/effect-boundaries.ts):
+## The architecture Gate protects how Redproof is built
 
-- `core-no-ambient-inputs`: a core module cannot read `process.cwd()` or
-  `process.env`. The shell reads them and passes values in.
-- `effects-allowlisted-boundaries`: filesystem, process, clock, randomness,
-  timer, and subprocess effects may appear only in the 23 files listed in
-  [`gates/support/effects-model.ts`](../gates/support/effects-model.ts).
-- `core-tests-no-io-helpers`: a core test cannot import a filesystem,
-  subprocess, or workspace fixture helper.
+Redproof has a functional core and an imperative shell. Core modules make
+decisions from values. Boundary modules read files, inspect the environment,
+observe time, and supervise processes.
 
-**Why it is powerful.** A new effect site is a breach, not a habit. Adding one
-means editing the allowlist in a visible, reviewed change. The core therefore
-stays a set of pure functions, and a pure function is tested with plain
-values. No temporary directory, no subprocess, no clock. This core test builds
-a result by hand and checks one decision:
+The architecture Gate makes that design executable. It prevents contexts from
+reaching through each other's private modules, keeps domain types independent,
+restricts effects to reviewed boundary files, and keeps filesystem helpers out
+of functional-core tests.
+
+The corresponding proofs do more than assert that dependency-cruiser or the
+syntax scanner ran. They introduce the forbidden relationships:
 
 ```text
-const scan: Scan = { source: 'unit', startedAt: '', finishedAt: '', inspected: 1 };
-const R1 = { id: 'r1', description: 'R1' } as const;
-const R2 = { id: 'r2', description: 'R2' } as const;
-
-test('RED proof requires its target Rule, not merely a failed Gate', () => {
-  const result = fail(scan, [
-    breach(R2.id, { code: 'r2', message: 'R2 failed', location: null }),
-  ]);
-
-  assert.deepEqual(evaluateProof(proof.red(R1, 'prove R1', noop), result), {
-    kind: 'target-rule-not-breached',
-    target: 'r1',
-    breached: ['r2'],
-  });
-});
+create two production modules that import each other
+append a filesystem import to a core module
+make a core module import its shell
+read process.cwd() inside the functional core
+make an Adapter import Redproof internals
 ```
 
-`npm run test:core` runs that lane alone. The Gate guards the lane too. Its
-proof appends `import './helpers/workspace.ts'` to a core test and expects
-FAIL.
+Each mutation must breach the Rule that names that boundary. This matters as
+the codebase grows: an architectural convention cannot quietly become a
+diagram that no longer matches the implementation.
 
-## Gate 2: static-contracts
+## Redproof also guards the guardrail integrations
 
-**The promise.** The workspace type-checks. Every standalone TypeScript example
-in the documentation compiles. The number of examples excused from that check
-cannot grow.
+An Adapter can return the right TypeScript shape and still be unsafe. It might
+accept invalid options, turn a crashed tool into a false PASS, parse untrusted
+output inside an I/O-heavy shell, claim evidence its report cannot provide, or
+create Breaches from the wrong findings.
 
-Source: [`gates/static-contracts.ts`](../gates/static-contracts.ts).
+The [`adapter-contracts`](../gates/adapter-contracts.ts) Gate protects five
+shared promises against ESLint, dependency-cruiser, Stryker, the generic
+testing Adapter, and Vitest. It runs two complementary implementations of each
+contract side by side:
 
-**A custom-made guardrail.** No package checks documentation examples. Two
-small scripts in this repository do it. One extracts every ` ```ts ` block from
-the docs and compiles it. The other counts the ` ```ts fragment ` blocks that
-are excused, and fails when the count exceeds a limit. Redproof wraps both as
-Rules with `redproof/command`, next to the workspace compiler:
+- the original focused contract suites;
+- package-owned registrations executed by
+  [`@redproof/adapter-tck`](../packages/adapter-tck/README.md).
+
+The TCK owns the reusable assertions, while each Adapter owns the scenarios
+that exercise its public behavior. The TCK also runs deliberately broken
+specimens against itself. That proves it rejects invalid Adapters rather than
+merely confirming that the current built-ins happen to pass.
+
+Real-tool fixtures add the final layer. They run ESLint, dependency-cruiser,
+Stryker, and Vitest against representative projects and prove their actual
+tool boundaries. The fast contract Gate identifies which shared promise broke;
+the integration fixtures show that the promise holds when the external tool is
+really involved.
+
+This dependency direction keeps the production graph clean:
 
 ```text
-const check = commands({
-  mode: 'parallel',
-  maxAtOnce: 3,
-  entries: [
-    { rule: rules.workspaceCompiles,   command: node, args: tsc('--noEmit') },
-    { rule: rules.docsExamplesCompile, command: node, args: stripTypes('scripts/typecheck-docs.ts') },
-    { rule: rules.docsFragmentDebt,    command: node, args: stripTypes('gates/support/check-doc-fragment-budget.ts') },
-  ],
-});
+Adapter production ──▶ redproof
+Adapter tests      ──▶ @redproof/adapter-tck ──peer/types──▶ redproof
+root Gate          ──▶ package-owned TCK tests
 ```
 
-That is the whole integration. A script that exits non-zero is a Rule breach.
-A script that cannot start is a REFUSE. Nothing about Redproof had to change
-to guard the docs.
+Redproof does not depend on the TCK, Adapter production does not import it, and
+the TCK does not import built-in Adapters.
 
-**The proofs.** One plants a type error in a test file. One plants a markdown
-file with a checked example that does not compile. One plants a markdown file
-with one excused fragment. Each expects FAIL.
+## The release is guarded like product code
 
-## How a proof drives tidy-up
+Dogfooding stops being convincing if it protects source code but not what users
+install.
 
-A proof does not only catch a broken Rule. It catches a Rule that has gone
-slack. This happened on 2026-09-08.
+The repository-policy Gate reads the six package manifests, public exports,
+source inventory, automation workflows, and documentation links. It checks
+that packages share a version, internal dependency pins match, public runtime
+and type surfaces are backed by source, and CI cannot silently drop required
+verification.
 
-A change moved two documentation examples into checked blocks. The fragment
-count fell from 39 to 37. `self:check` stayed green, because 37 is under the
-limit of 39. `self:prove` failed:
+The release workflow then packs all six packages and installs them into a clean
+consumer. It verifies runtime imports, published types, CLI behavior, package
+contents, and exact internal links before npm publishing is allowed.
 
-```text
-✗ static-contracts / rejects growth in unchecked documentation fragments expected=red actual=pass
-    expected fail, got pass; the mutation did not reach what the Rule guards
-```
+The proofs cover this boundary too. A deliberately omitted package must breach
+the inventory Rule. A divergent version must breach alignment. A removed CI
+verification step must breach automation policy. An unreadable policy input
+must REFUSE rather than let an incomplete release inspection pass.
 
-The proof plants exactly one fragment. With the debt at 37 and the limit at
-39, one more fragment makes 38, and nothing breaches. The Rule "fragment debt
-must not grow" was no longer guarding anything. Two fragments could have crept
-back in unnoticed.
+See the live [CI workflow](../.github/workflows/ci.yml) and
+[publish workflow](../.github/workflows/publish.yml).
 
-The only fix was to lower the limit to 37. The proof forced the ratchet down.
-The maintainer did not get to leave slack in the budget. That is the point of
-red proving: green is not evidence until red has been seen.
+## What goes beyond a typical guardrail runner
 
-## Gate 3: test-health
+A command runner can tell you that ESLint, a test suite, or a custom script
+exited successfully. Redproof can use that evidence, but its model adds several
+important guarantees:
 
-**The promise.** A green test run means every test ran and passed. Not most of
-them. Not the ones nobody skipped.
+- **The promise has a name.** Failures are attributed to stable Rules, not only
+  to a command or job.
+- **Detection is exercised.** A RED proof supplies a controlled counterexample
+  and requires the targeted Rule to notice it.
+- **The healthy state is exercised.** GREEN proves the Gate is capable of
+  accepting a valid project.
+- **Uncertainty stays visible.** REFUSE prevents missing or insufficient
+  evidence from becoming false confidence.
+- **The real scope is preserved.** Check and prove run the same Gate rather
+  than a weakened proof-only version.
+- **The mechanism is composable.** A new guardrail can begin as an executable,
+  a structured Adapter, or a native Check and still participate in the same
+  proof lifecycle.
+- **The integrations are guarded too.** Adapter contracts, the TCK, real-tool
+  fixtures, and packed-consumer verification test the layers that translate
+  external evidence into Redproof decisions.
 
-Source: [`gates/test-health.ts`](../gates/test-health.ts).
+This is the practical difference between running guardrails and proving your
+guardrails still work.
 
-This Gate is the `@redproof/testing` adapter with a JUnit report. Redproof
-tests its own test adapter with itself. The runner starts `node --test` over
-`tests/**/*.test.ts` and asks for JUnit output. The adapter reads the report
-and exposes two Rules: `testsPass` and `noSkippedTests`.
+## Why this matters when agents write code
 
-**Example.** A developer marks a flaky test with `skip` to get the build green.
-The Gate breaches `testing/no-skipped-tests` and names the test. The skip is
-a finding, not an escape.
+AI agents can change more code, configuration, and documentation in one pass
+than a person would usually touch at once. They can also produce plausible
+mistakes at the same speed. Reliable guardrails become part of the steering
+loop: they tell the agent what crossed a boundary and give it concrete evidence
+to course-correct.
 
-**The proofs.** One creates a test file with one failing test. One creates a
-test file with one skipped test. Each expects FAIL.
+But an agent can only respond to a signal that still works. A stale glob, an
+ignored report field, a missing package in automation, or a parser that turns
+unavailable evidence into PASS can make a pipeline confidently wrong.
 
-## Gate 4: adapter-contracts
+Redproof does not decide what a team's standards should be. It lets the team
+compose those standards from the tools and evidence it already trusts, then
+continuously demonstrates that the resulting guardrails remain sensitive to
+the problems they were built to catch.
 
-**The promise.** Every built-in Adapter validates options before execution,
-REFUSES unavailable runs, keeps parsers and evidence models pure, declares
-report capabilities where they apply, and creates Breaches only from selected
-structured evidence.
+## Run the dogfood portfolio
 
-Source: [`gates/adapter-contracts.ts`](../gates/adapter-contracts.ts).
-
-Ten small contract commands run in parallel: one legacy suite and one
-package-owned TCK lane per Rule. Each RED proof makes one precise promise
-false: it removes constructor validation, corrupts runner mapping, introduces
-I/O into a pure model, reads ambient process state, overstates JUnit
-capabilities, or drops a selected ESLint finding. A flooded output budget
-supplies the REFUSE proof.
-
-The command timeout is 60 seconds. It is a safety net, not a speed budget. The
-suites finish much sooner, but a shared machine can be many times slower. A
-tight timeout turns a slow machine into a false refusal, which reads like a
-broken contract.
-
-See **[Gating Adapter contracts](adapter-contract-gates.md)** for the contract
-matrix and the RED-first sequence used to build it.
-
-## Gate 5: repository-policy
-
-**The promise.** Six packages ship together. They share one version. Every
-one of them is in every build and release step. The public surfaces are
-declared and backed by source. CI keeps its verification steps. No document
-links to a missing file.
-
-Source: [`gates/repository-policy.ts`](../gates/repository-policy.ts).
-
-This Gate is a native Check over a pure policy model. The shell reads the
-package manifests, the workflow files, and the markdown. The core evaluates
-the five Rules over those values. The Check is composed with the
-`scanning` helper in `gates/support`, which stamps the scan window, counts
-what was inspected, maps findings to breaches, and REFUSES when an input
-cannot be read.
-
-**Examples.** Someone adds a seventh package and forgets the version setter:
-`repository/packages-inventory-is-consistent` breaches. Someone bumps one
-package to a new version and forgets the others:
-`repository/package-versions-and-internal-pins-align` breaches. A document
-links to a file that was renamed: `repository/docs-relative-links-resolve`
-breaches and names the link.
-
-**The proofs.** Five RED proofs replace one string each: a package name in the
-inventory, a version, a schema entry, a CI step, and a link target. The REFUSE
-proof renames `ci.yml` and expects REFUSE, because a policy input cannot be
-read. The Gate does not guess.
-
-## What this shows
-
-Every Gate above guards a different kind of evidence. A module graph. An AST.
-A compiler exit code. A JUnit report. A set of JSON manifests and markdown
-files. Redproof did not need a feature for any of them. Each one is a Rule, a
-Check that gathers evidence, and a Proof that plants the defect.
-
-Three directories keep the Gate files readable:
-
-```text
-gates/*.ts            what is protected, and how each Rule is broken
-gates/checks/*.ts     how a Check gathers input and reports findings
-gates/support/*.ts    pure models and shared plumbing
-```
-
-To run the suite yourself, build once and use the three scripts:
+Describe the five Gates as an executable specification:
 
 ```bash
-npm run build
 npm run self:describe
+```
+
+Check the current repository:
+
+```bash
 npm run self:check
+```
+
+Run every controlled defect, healthy baseline, and refusal scenario:
+
+```bash
 npm run self:prove
 ```
 
-`npm run check` runs all of it in CI, after the type, documentation, test, and
-fixture verification.
+The complete delivery check runs those self-hosted Gates together with types,
+documentation examples, native tests, and the real-tool fixture portfolio:
 
-## Next
+```bash
+npm run check
+```
 
-- **[Composing Redproof](composition.md)** for Rules, Checks, Proofs, and Mutations.
-- **[Command Checks](commands.md)** for wrapping a script or executable, as `static-contracts` does.
-- **[Custom Adapter](custom-adapter.md)** for a tool with its own policy model.
+The implementation is intentionally readable. Start with the five files in
+[`gates/`](../gates), then see the reusable
+[Contract-to-Gate method](contract-to-gate.md), the
+[Adapter contract design](adapter-contract-gates.md), and the
+[custom Adapter guidelines](custom-adapter.md).
+
+The repository's claim is not merely that Redproof can run many kinds of
+guardrail. It is that a guardrail is more trustworthy when the project can show
+all three outcomes: the healthy system passes, a representative defect breaches
+the expected Rule, and unavailable evidence is refused.


### PR DESCRIPTION
## Why

`docs/red-proving-redproof.md` read like an implementation log: dated incidents, timing notes, cleanup stories, and a long Gate-by-Gate inventory obscured the reason the page exists.

The page should showcase Redproof's own dogfooding and the capability that distinguishes it from a typical guardrail runner: Redproof does not only run checks; it demonstrates that each guardrail still detects a representative defect and refuses when evidence is not trustworthy.

## What changed

Rewrite the page from scratch around the dogfooding model:

- healthy repository -> PASS;
- controlled defect -> FAIL the targeted Rule;
- unavailable evidence -> REFUSE.

The new narrative shows how the same model protects architecture, types and documentation, test evidence, Adapter/TCK contracts, and release integrity. It also explains isolated proof mutations, precise Rule attribution, clean-consumer package verification, and why dependable feedback helps AI agents course-correct.

Historical narration and exhaustive mutation inventories were removed. The live Gate source and focused method documents remain linked for readers who want implementation detail.

## Verification

- all 30 checked documentation examples compile;
- the unchecked-fragment budget remains 37;
- `static-contracts` and `repository-policy` hold all 8 Rules;
- both documentation-facing proof portfolios pass, including RED, REFUSE, and GREEN outcomes;
- `git diff --check` is clean.
