### PR TITLE
Make npm publishing resumable

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -113,10 +113,20 @@ jobs:
 
       - name: Publish to npm
         if: github.event_name == 'release' || github.event.inputs.dry-run == 'false'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          NPM_TAG: ${{ steps.version.outputs.npm-tag }}
         run: |
+          set -euo pipefail
+
           for PKG in redproof @redproof/adapter-tck @redproof/eslint @redproof/dependency-cruiser @redproof/stryker @redproof/testing; do
+            if npm view "${PKG}@${VERSION}" version --json >/dev/null 2>&1; then
+              echo "Skipping ${PKG}@${VERSION}: already published"
+              continue
+            fi
+
             echo "Publishing $PKG"
-            npm publish -w "$PKG" --tag "${{ steps.version.outputs.npm-tag }}" --provenance
+            npm publish -w "$PKG" --tag "$NPM_TAG" --provenance
           done
 
       - name: Report a dry run


### PR DESCRIPTION
Summary:
- check the registry before publishing each workspace package
- skip an exact package version that is already published
- keep later packages publishable after a partial release failure

Why:
The v0.11.0 release published redproof before the first publication of the adapter TCK failed. Retrying the workflow would otherwise stop immediately because redproof 0.11.0 is immutable and already exists.

Verification:
- npm run test:core: 292 passed
- npm run check: 632 tests plus all self-checks and proofs passed
