### PR TITLE
Harden adapter TCK and repository guardrails

### DIFF
--- a/docs/adapter-contract-gates.md
+++ b/docs/adapter-contract-gates.md
@@ -60,7 +60,7 @@ inventing report capabilities for them would make the design less honest.
    evidence from the wrapped external tool.
 5. Prove the Gate causally. Each Rule has a RED proof that removes or corrupts
    the behavior it protects. The suite also has a GREEN proof and a REFUSE proof
-   that terminates one wrapped contract process by signal.
+   that makes one wrapped contract process exceed its output budget.
 6. Keep compile-time and runtime validation together. Public type probes reject
    unknown option keys for TypeScript consumers, while constructor probes cover
    JavaScript and type-stripped Gate loading.
@@ -111,15 +111,22 @@ public behavior they protect.
 
 The `runAdapterTck()` helper owns every assertion. A registration must provide
 a valid construction, bad-option probes, an unavailable execution, selected,
-clean, and unselected structured evidence, a purity profile, and an explicit
-report-capability profile. ESLint, dependency-cruiser, Stryker, the generic
-testing Adapter, and the Vitest convenience Adapter are registered.
+clean, and unselected structured evidence with the exact expected Breach
+identities, a purity profile, and an explicit report-capability profile. ESLint,
+dependency-cruiser, Stryker, the generic testing Adapter, and the Vitest
+convenience Adapter are registered.
 
 The TCK emits contract-tagged Node test cases. The existing Gate selects one
 tag per command, so a failure still breaches the precise Redproof Rule rather
 than a vague “Adapter incompatible” Rule. Adding another registration therefore
 places the new Adapter under every applicable contract without editing five
 assertion suites.
+
+The registration remains trusted test code. The TCK can reject malformed or
+inconsistent observations, but no test kit can prove that a deliberately fake
+callback exercised the real Adapter. Adapter-owned probes should call the
+public behavior they claim to observe; real-tool fixtures close that final
+boundary.
 
 The dependency direction is deliberate:
 

--- a/docs/red-proving-redproof.md
+++ b/docs/red-proving-redproof.md
@@ -122,9 +122,11 @@ contract side by side:
   [`@redproof/adapter-tck`](../packages/adapter-tck/README.md).
 
 The TCK owns the reusable assertions, while each Adapter owns the scenarios
-that exercise its public behavior. The TCK also runs deliberately broken
-specimens against itself. That proves it rejects invalid Adapters rather than
-merely confirming that the current built-ins happen to pass.
+that exercise its public behavior. Its self-tests deliberately feed it
+malformed and inconsistent observations, proving those contract checks reject
+bad evidence rather than merely confirming that current registrations pass.
+The Adapter-owned callbacks are still trusted test code; real-tool fixtures
+verify that they cross the actual Adapter boundary.
 
 Real-tool fixtures add the final layer. They run ESLint, dependency-cruiser,
 Stryker, and Vitest against representative projects and prove their actual
@@ -150,18 +152,19 @@ install.
 
 The repository-policy Gate reads the six package manifests, public exports,
 source inventory, automation workflows, and documentation links. It checks
-that packages share a version, internal dependency pins match, public runtime
-and type surfaces are backed by source, and CI cannot silently drop required
-verification.
+that packages share a version, internal dependency pins match, package edges
+follow the core–TCK–Adapter layers, public runtime and type surfaces are backed
+by source, and CI cannot silently drop required verification.
 
 The release workflow then packs all six packages and installs them into a clean
 consumer. It verifies runtime imports, published types, CLI behavior, package
 contents, and exact internal links before npm publishing is allowed.
 
 The proofs cover this boundary too. A deliberately omitted package must breach
-the inventory Rule. A divergent version must breach alignment. A removed CI
-verification step must breach automation policy. An unreadable policy input
-must REFUSE rather than let an incomplete release inspection pass.
+the inventory Rule. A divergent version must breach alignment. A forbidden
+runtime dependency from core to the TCK must breach package boundaries. A
+removed CI verification step must breach automation policy. An unreadable
+policy input must REFUSE rather than let an incomplete release inspection pass.
 
 See the live [CI workflow](../.github/workflows/ci.yml) and
 [publish workflow](../.github/workflows/publish.yml).

--- a/gates/adapter-contracts.ts
+++ b/gates/adapter-contracts.ts
@@ -163,6 +163,11 @@ export const proofs = defineProofs(gate, [
     mutate.appendText('packages/stryker/src/model.ts', '\nvoid process.cwd();\n'),
   ),
   proof.red(
+    rules.pureParsers,
+    'detects qualified ambient state inside a pure evidence model',
+    mutate.appendText('packages/eslint/src/model.ts', '\nvoid globalThis.Date.now();\n'),
+  ),
+  proof.red(
     rules.reportCapabilities,
     'detects a report format that overstates what it can observe',
     mutate.replaceText(

--- a/gates/repository-policy.ts
+++ b/gates/repository-policy.ts
@@ -10,6 +10,10 @@ const rules = defineRules({
     id: 'repository/package-versions-and-internal-pins-align',
     description: 'All packages share one version and internal Redproof dependencies use it exactly.',
   },
+  packageBoundaries: {
+    id: 'repository/internal-package-boundaries-hold',
+    description: 'Internal package dependencies follow the core, TCK, and Adapter layers.',
+  },
   publicFiles: {
     id: 'repository/public-files-are-declared',
     description: 'Public runtime, type, binary, subpath, and schema surfaces are source-backed and declared.',
@@ -59,6 +63,14 @@ export const proofs = defineProofs(gate, [
     mutate.replaceText(
       locate.text({ files: 'packages/testing/package.json', find: '"version": "0.10.0"' }),
       '"version": "0.6.1"',
+    ),
+  ),
+  proof.red(
+    rules.packageBoundaries,
+    'detects a runtime dependency from Redproof core to the Adapter TCK',
+    mutate.replaceText(
+      locate.text({ files: 'packages/redproof/package.json', find: '  "repository": {' }),
+      '  "dependencies": { "@redproof/adapter-tck": "0.10.0" },\n  "repository": {',
     ),
   ),
   proof.red(

--- a/gates/support/repository-policy-model.ts
+++ b/gates/support/repository-policy-model.ts
@@ -39,6 +39,7 @@ export type RepositorySnapshot = {
 export type RepositoryPolicyRule =
   | 'packageInventory'
   | 'versionAlignment'
+  | 'packageBoundaries'
   | 'publicFiles'
   | 'automationVerification'
   | 'docsLinks';
@@ -132,6 +133,44 @@ function versionAlignment(snapshot: RepositorySnapshot): RepositoryPolicyFinding
       }
     }
   }
+  return findings;
+}
+
+function packageBoundaries(snapshot: RepositorySnapshot): RepositoryPolicyFinding[] {
+  const findings: RepositoryPolicyFinding[] = [];
+  const internalNames = new Set(snapshot.manifests.map(pkg => pkg.name));
+  const tck = '@redproof/adapter-tck';
+
+  for (const pkg of snapshot.manifests) {
+    for (const section of ['dependencies', 'devDependencies', 'peerDependencies'] as const) {
+      for (const dependency of Object.keys(pkg.manifest[section] ?? {})) {
+        if (!internalNames.has(dependency)) continue;
+
+        const allowed = pkg.name === 'redproof'
+          ? false
+          : pkg.name === tck
+            ? dependency === 'redproof' && section === 'peerDependencies'
+            : (dependency === 'redproof' && section === 'dependencies')
+              || (dependency === tck && section === 'devDependencies');
+        if (allowed) continue;
+
+        const message = pkg.name === 'redproof'
+          ? `redproof must not depend on ${dependency} through ${section}.`
+          : dependency === tck
+            ? `${pkg.name} may use ${tck} only through devDependencies.`
+            : dependency === 'redproof'
+              ? `${pkg.name} may use redproof only through dependencies.`
+              : `${pkg.name} must not depend on ${dependency} through ${section}.`;
+        findings.push({
+          rule: 'packageBoundaries',
+          code: 'internal-package-boundary-violated',
+          message,
+          file: pkg.file,
+        });
+      }
+    }
+  }
+
   return findings;
 }
 
@@ -283,6 +322,7 @@ export function evaluateRepositoryPolicy(snapshot: RepositorySnapshot): Reposito
   return [
     ...packageInventory(snapshot),
     ...versionAlignment(snapshot),
+    ...packageBoundaries(snapshot),
     ...publicFiles(snapshot),
     ...automationVerification(snapshot),
     ...docsLinks(snapshot),

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "demo:composition:json": "node --disable-warning=ExperimentalWarning --experimental-strip-types scripts/demo-fixture.ts composition-json",
     "demo:composition:json:prove": "node --disable-warning=ExperimentalWarning --experimental-strip-types scripts/demo-proof-fixture.ts composition-json",
     "test:adapters": "node --disable-warning=ExperimentalWarning --experimental-strip-types --test 'tests/adapters/**/*.test.ts' 'tests/fixtures/**/*.test.ts' 'packages/*/test/adapter.tck.test.ts'",
-    "test:adapter-tck": "node --disable-warning=ExperimentalWarning --experimental-strip-types --test 'packages/adapter-tck/test/**/*.test.ts' 'packages/*/test/adapter.tck.test.ts'",
+    "test:adapter-tck": "npm run build && node --disable-warning=ExperimentalWarning --experimental-strip-types --test 'packages/adapter-tck/test/**/*.test.ts' 'packages/*/test/adapter.tck.test.ts'",
     "demo:dependency-cruiser": "node --disable-warning=ExperimentalWarning --experimental-strip-types scripts/demo-fixture.ts dependency-cruiser-project",
     "demo:dependency-cruiser:prove": "node --disable-warning=ExperimentalWarning --experimental-strip-types scripts/demo-proof-fixture.ts dependency-cruiser-project",
     "demo:stryker": "node --disable-warning=ExperimentalWarning --experimental-strip-types scripts/demo-fixture.ts stryker-project",

--- a/packages/adapter-tck/README.md
+++ b/packages/adapter-tck/README.md
@@ -48,6 +48,7 @@ const spec = {
   }],
   evidence: [{
     rule: 'example/valid',
+    expectedBreaches: [{ code: 'example-invalid', message: 'bad example' }],
     violating: () => ({ kind: 'translated', breaches: exampleBreaches(['bad']) }),
     clean: () => ({ kind: 'translated', breaches: exampleBreaches([]) }),
     unselected: () => ({ kind: 'translated', breaches: [] }),
@@ -70,6 +71,12 @@ The TCK covers construction, unavailable execution, functional-core purity,
 report capabilities, and structured evidence. When one implementation surface
 delegates its evidence model to another, register both specs in the same call
 and use `{ kind: 'delegated', to: 'other-name' }`.
+
+The registration is trusted test code. The TCK validates the shape and
+consistency of the observations it receives—including exact expected Breach
+identities—but it cannot prove that an intentionally fabricated callback called
+the real Adapter. Keep the probes close to the Adapter's public API and use a
+real-tool integration fixture to verify the external-tool boundary.
 
 The package is test infrastructure. Adapter production source must not import
 it; list it only in `devDependencies`.

--- a/packages/adapter-tck/src/effects.ts
+++ b/packages/adapter-tck/src/effects.ts
@@ -28,6 +28,30 @@ function isPropertyName(node: ts.Identifier): boolean {
     || (ts.isMethodDeclaration(parent) && parent.name === node);
 }
 
+function expressionPath(node: ts.Expression): readonly string[] | undefined {
+  if (ts.isIdentifier(node)) return [node.text];
+  if (!ts.isPropertyAccessExpression(node)) return undefined;
+  const owner = expressionPath(node.expression);
+  return owner ? [...owner, node.name.text] : undefined;
+}
+
+function globalPath(node: ts.Expression): {
+  readonly path: readonly string[];
+  readonly qualified: boolean;
+} | undefined {
+  const path = expressionPath(node);
+  if (!path?.length) return undefined;
+  const qualified = path[0] === 'globalThis' || path[0] === 'global';
+  return { path: qualified ? path.slice(1) : path, qualified };
+}
+
+function isConsumedExpression(node: ts.Expression): boolean {
+  const parent = node.parent;
+  return (ts.isPropertyAccessExpression(parent) && parent.expression === node)
+    || (ts.isCallExpression(parent) && parent.expression === node)
+    || (ts.isNewExpression(parent) && parent.expression === node);
+}
+
 function importedEffect(node: ts.Node): string | undefined {
   if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
     const specifier = node.moduleSpecifier;
@@ -63,25 +87,31 @@ function ambientEffect(node: ts.Node): string | undefined {
     return 'process';
   }
 
-  if (ts.isNewExpression(node)
-      && ts.isIdentifier(node.expression)
-      && node.expression.text === 'Date'
-      && (node.arguments?.length ?? 0) === 0) {
-    return 'new Date';
+  if (ts.isPropertyAccessExpression(node) && !isConsumedExpression(node)) {
+    const expression = globalPath(node);
+    if (expression?.qualified && expression.path[0] === 'process') return 'process';
+  }
+
+  if (ts.isNewExpression(node) && (node.arguments?.length ?? 0) === 0) {
+    const expression = globalPath(node.expression);
+    if (expression?.path.length === 1 && expression.path[0] === 'Date') return 'new Date';
   }
 
   if (ts.isCallExpression(node)) {
-    if (ts.isIdentifier(node.expression)
-        && ['setTimeout', 'setInterval', 'setImmediate'].includes(node.expression.text)) {
-      return node.expression.text;
+    const expression = globalPath(node.expression);
+    const path = expression?.path ?? [];
+    if (path.length === 1
+        && ['fetch', 'setTimeout', 'setInterval', 'setImmediate', 'queueMicrotask'].includes(path[0]!)) {
+      return path[0];
     }
-
-    if (ts.isPropertyAccessExpression(node.expression)) {
-      const owner = node.expression.expression;
-      const member = node.expression.name.text;
-      if (ts.isIdentifier(owner) && owner.text === 'Date' && member === 'now') return 'Date.now';
-      if (ts.isIdentifier(owner) && owner.text === 'Math' && member === 'random') return 'Math.random';
-      if (ts.isIdentifier(owner) && owner.text === 'performance') return `performance.${member}`;
+    if (expression?.qualified && path[0] === 'process') return 'process';
+    if (path.length === 2 && path[0] === 'Date' && path[1] === 'now') return 'Date.now';
+    if (path.length === 2 && path[0] === 'Math' && path[1] === 'random') return 'Math.random';
+    if (path.length === 2 && path[0] === 'performance') return `performance.${path[1]}`;
+    if (path.length === 2
+        && path[0] === 'crypto'
+        && ['getRandomValues', 'randomUUID'].includes(path[1]!)) {
+      return `crypto.${path[1]}`;
     }
   }
 

--- a/packages/adapter-tck/src/index.ts
+++ b/packages/adapter-tck/src/index.ts
@@ -28,8 +28,14 @@ export type EvidenceObservation =
   | { readonly kind: 'translated'; readonly breaches: readonly AnyBreach[] }
   | { readonly kind: 'checked'; readonly result: AnyCheckResult };
 
+export type BreachExpectation = {
+  readonly code: string;
+  readonly message?: string | RegExp;
+};
+
 export type EvidenceProbe = {
   readonly rule: string;
+  readonly expectedBreaches: NonEmpty<BreachExpectation>;
   readonly violating: () => MaybePromise<EvidenceObservation>;
   readonly clean: () => MaybePromise<EvidenceObservation>;
   readonly unselected: () => MaybePromise<EvidenceObservation>;
@@ -92,6 +98,34 @@ function assertAdapter(adapter: AnyAdapter, spec: AdapterTckSpec): void {
   assert.equal(new Set(rules.map(rule => rule.id)).size, rules.length, 'Rule ids must be unique');
 }
 
+function assertEvidenceRules(adapter: AnyAdapter, spec: AdapterTckSpec): void {
+  const ruleIds = new Set(Object.values(adapter.rules as Readonly<Record<string, Rule>>).map(rule => rule.id));
+  for (const probe of spec.evidence) {
+    assert.ok(
+      ruleIds.has(probe.rule),
+      `${spec.name} does not expose evidence Rule ${probe.rule}`,
+    );
+  }
+}
+
+function assertCheckResultShape(result: AnyCheckResult): void {
+  const expected = result.verdict === 'pass'
+    ? ['scan', 'verdict']
+    : result.verdict === 'fail'
+      ? ['breaches', 'scan', 'verdict']
+      : ['scan', 'verdict', 'why'];
+  const description = result.verdict === 'pass'
+    ? 'verdict and scan'
+    : result.verdict === 'fail'
+      ? 'verdict, scan, and breaches'
+      : 'verdict, scan, and why';
+  assert.deepEqual(
+    Object.keys(result).sort(),
+    expected,
+    `${result.verdict.toUpperCase()} result must contain only ${description}`,
+  );
+}
+
 async function expectThrow(probe: ThrowProbe): Promise<void> {
   await assert.rejects(Promise.resolve().then(probe.run), probe.message);
 }
@@ -101,6 +135,8 @@ function breachesOf(
   expected: 'violation' | 'none',
 ): readonly AnyBreach[] {
   if (observation.kind === 'translated') return observation.breaches;
+
+  assertCheckResultShape(observation.result);
 
   if (expected === 'violation') {
     assert.equal(observation.result.verdict, 'fail');
@@ -112,10 +148,20 @@ function breachesOf(
   return [];
 }
 
-function assertStructuredBreach(breach: AnyBreach, rule: string): void {
+function assertStructuredBreach(
+  breach: AnyBreach,
+  rule: string,
+  expected: BreachExpectation,
+): void {
   assert.equal(breach.rule, rule);
-  assert.ok(breach.code.trim(), 'a Breach must have a diagnostic code');
-  assert.ok(breach.message.trim(), 'a Breach must have a diagnostic message');
+  assert.equal(breach.code, expected.code);
+  if (expected.message instanceof RegExp) {
+    assert.match(breach.message, expected.message);
+  } else if (expected.message !== undefined) {
+    assert.equal(breach.message, expected.message);
+  } else {
+    assert.ok(breach.message.trim(), 'a Breach must have a diagnostic message');
+  }
 }
 
 function repositoryPath(file: string, specifier: string): string {
@@ -173,7 +219,9 @@ function constructorCases(spec: AdapterTckSpec): AdapterTckCase[] {
       contract: 'constructor-options',
       name: 'accepts a valid configuration',
       run() {
-        assertAdapter(spec.construction.valid(), spec);
+        const adapter = spec.construction.valid();
+        assertAdapter(adapter, spec);
+        assertEvidenceRules(adapter, spec);
       },
     },
     ...probes.map((probe): AdapterTckCase => ({
@@ -192,6 +240,7 @@ function unavailableCases(spec: AdapterTckSpec): AdapterTckCase[] {
     name: probe.name,
     async run() {
       const result = await probe.run();
+      assertCheckResultShape(result);
       assert.equal(result.verdict, 'refuse');
       if (result.verdict === 'refuse') {
         assert.equal(
@@ -213,8 +262,13 @@ function evidenceCases(spec: AdapterTckSpec): AdapterTckCase[] {
       name: `${probe.rule} breaches for selected structured evidence`,
       async run() {
         const breaches = breachesOf(await probe.violating(), 'violation');
-        assert.ok(breaches.length > 0, 'selected violating evidence must create a Breach');
-        for (const breach of breaches) assertStructuredBreach(breach, probe.rule);
+        assert.equal(
+          breaches.length,
+          probe.expectedBreaches.length,
+          `selected evidence must preserve ${probe.expectedBreaches.length} expected ${probe.expectedBreaches.length === 1 ? 'Breach' : 'Breaches'}`,
+        );
+        breaches.forEach((breach, index) =>
+          assertStructuredBreach(breach, probe.rule, probe.expectedBreaches[index]!));
       },
     },
     {

--- a/packages/adapter-tck/test/adapter-tck.behavior.test.ts
+++ b/packages/adapter-tck/test/adapter-tck.behavior.test.ts
@@ -8,6 +8,7 @@ import {
   type CheckResult,
 } from 'redproof';
 import {
+  analyzeSourceEffects,
   adapterTckCases,
   type AdapterTckCase,
   type AdapterTckContract,
@@ -71,6 +72,7 @@ function sampleSpec(overrides: Partial<AdapterTckSpec> = {}): AdapterTckSpec {
     }],
     evidence: [{
       rule: rule.id,
+      expectedBreaches: [{ code: 'sample-breach', message: 'sample breach' }],
       violating: () => ({
         kind: 'translated',
         breaches: [{ rule: rule.id, code: 'sample-breach', message: 'sample breach', location: null }],
@@ -130,10 +132,61 @@ test('the TCK rejects a nonconforming unavailable result', async () => {
   );
 });
 
+test('the TCK rejects a REFUSE result carrying fabricated Breaches', async () => {
+  const bad = sampleSpec({
+    unavailable: [{
+      name: 'unavailable',
+      code: 'sample-unavailable',
+      async run(): Promise<CheckResult> {
+        return {
+          ...result.refuse({ ...scan, inspected: null }, {
+            code: 'sample-unavailable',
+            message: 'sample unavailable',
+            location: null,
+          }),
+          breaches: [{
+            rule: rule.id,
+            code: 'fabricated',
+            message: 'fabricated breach',
+            location: null,
+          }],
+        } as CheckResult;
+      },
+    }],
+  });
+
+  await assert.rejects(
+    run(oneCase([bad], 'sample', 'unavailable-execution', /unavailable/u)),
+    /REFUSE result must contain only verdict, scan, and why/u,
+  );
+});
+
+test('the TCK rejects evidence for a Rule the constructed Adapter does not expose', async () => {
+  const foreign = defineRule({ id: 'sample/foreign', description: 'Foreign Rule.' });
+  const bad = sampleSpec({
+    evidence: [{
+      rule: foreign.id,
+      expectedBreaches: [{ code: 'foreign', message: 'foreign' }],
+      violating: () => ({
+        kind: 'translated',
+        breaches: [{ rule: foreign.id, code: 'foreign', message: 'foreign', location: null }],
+      }),
+      clean: () => ({ kind: 'translated', breaches: [] }),
+      unselected: () => ({ kind: 'translated', breaches: [] }),
+    }],
+  });
+
+  await assert.rejects(
+    run(oneCase([bad], 'sample', 'constructor-options', /valid configuration/u)),
+    /sample does not expose evidence Rule sample\/foreign/u,
+  );
+});
+
 test('the TCK rejects a translator that drops selected violating evidence', async () => {
   const bad = sampleSpec({
     evidence: [{
       rule: rule.id,
+      expectedBreaches: [{ code: 'sample-breach', message: 'sample breach' }],
       violating: () => ({ kind: 'translated', breaches: [] }),
       clean: () => ({ kind: 'translated', breaches: [] }),
       unselected: () => ({ kind: 'translated', breaches: [] }),
@@ -142,7 +195,30 @@ test('the TCK rejects a translator that drops selected violating evidence', asyn
 
   await assert.rejects(
     run(oneCase([bad], 'sample', 'structured-evidence', /breaches for selected/u)),
-    /must create a Breach/u,
+    /selected evidence must preserve 1 expected Breach/u,
+  );
+});
+
+test('the TCK rejects a translator that preserves only some selected findings', async () => {
+  const bad = sampleSpec({
+    evidence: [{
+      rule: rule.id,
+      expectedBreaches: [
+        { code: 'first', message: 'first finding' },
+        { code: 'second', message: 'second finding' },
+      ],
+      violating: () => ({
+        kind: 'translated',
+        breaches: [{ rule: rule.id, code: 'first', message: 'first finding', location: null }],
+      }),
+      clean: () => ({ kind: 'translated', breaches: [] }),
+      unselected: () => ({ kind: 'translated', breaches: [] }),
+    }],
+  });
+
+  await assert.rejects(
+    run(oneCase([bad], 'sample', 'structured-evidence', /breaches for selected/u)),
+    /selected evidence must preserve 2 expected Breaches/u,
   );
 });
 
@@ -171,6 +247,29 @@ test('the TCK rejects effects in a declared functional core', async () => {
     run(oneCase([bad], 'sample', 'pure-model', /effect-free/u)),
     /node:fs\/promises/u,
   );
+});
+
+test('the effect scanner rejects network access and qualified ambient inputs', () => {
+  const effects = analyzeSourceEffects([{
+    file: 'model.ts',
+    content: [
+      "await fetch('https://example.invalid');",
+      'void globalThis.Date.now();',
+      'void globalThis.setTimeout(() => {}, 1);',
+      'void globalThis.Math.random();',
+      'void globalThis.performance.now();',
+      'void globalThis.process.env;',
+    ].join('\n'),
+  }]);
+
+  assert.deepEqual(effects.map(item => item.effect), [
+    'fetch',
+    'Date.now',
+    'setTimeout',
+    'Math.random',
+    'performance.now',
+    'process',
+  ]);
 });
 
 test('a delegated purity contract executes the source profile it names', async () => {

--- a/packages/dependency-cruiser/test/adapter.tck.test.ts
+++ b/packages/dependency-cruiser/test/adapter.tck.test.ts
@@ -60,6 +60,7 @@ const spec = {
   }],
   evidence: [{
     rule: 'dependency-cruiser/no-cycles',
+    expectedBreaches: [{ code: 'no-cycles' }],
     violating: () => evidence('no-cycles'),
     clean: () => evidence(null),
     unselected: () => evidence('not-selected'),

--- a/packages/eslint/test/adapter.tck.test.ts
+++ b/packages/eslint/test/adapter.tck.test.ts
@@ -52,6 +52,7 @@ const spec = {
   }],
   evidence: [{
     rule: 'eslint/semi',
+    expectedBreaches: [{ code: 'semi', message: 'lint finding' }],
     violating: () => evidence('semi'),
     clean: () => evidence(null),
     unselected: () => evidence('quotes'),

--- a/packages/stryker/test/adapter.tck.test.ts
+++ b/packages/stryker/test/adapter.tck.test.ts
@@ -52,6 +52,7 @@ const spec = {
   }],
   evidence: [{
     rule: 'stryker/mutants-detected',
+    expectedBreaches: [{ code: 'mutant-survived' }],
     violating: () => evidence('Survived'),
     clean: () => evidence(null),
     unselected: () => evidence('Killed'),

--- a/packages/testing/test/adapter.tck.test.ts
+++ b/packages/testing/test/adapter.tck.test.ts
@@ -93,6 +93,7 @@ const testingSpec = {
   }],
   evidence: [{
     rule: 'testing/tests-pass',
+    expectedBreaches: [{ code: 'test-failed', message: 'example' }],
     violating: () => evidence('failed'),
     clean: () => evidence('passed'),
     unselected: () => evidence('skipped'),
@@ -193,6 +194,7 @@ const vitestSpec = {
   }],
   evidence: [{
     rule: 'testing/tests-pass',
+    expectedBreaches: [{ code: 'test-failed' }],
     violating: () => checked(failingReport, { testsPass: true }),
     clean: () => checked(passingReport, { testsPass: true }),
     unselected: () => checked(failingReport, { noSkippedTests: true }),

--- a/tests/gates/checks.test.ts
+++ b/tests/gates/checks.test.ts
@@ -164,6 +164,7 @@ test('effectBoundaries REFUSES when a source it must scan cannot be read', async
 const policyRules = {
   packageInventory: defineRule({ id: 'probe/inventory', description: 'Inventory is consistent.' }),
   versionAlignment: defineRule({ id: 'probe/versions', description: 'Versions align.' }),
+  packageBoundaries: defineRule({ id: 'probe/package-boundaries', description: 'Package boundaries hold.' }),
   publicFiles: defineRule({ id: 'probe/public-files', description: 'Public files are declared.' }),
   automationVerification: defineRule({ id: 'probe/automation', description: 'Automation verifies.' }),
   docsLinks: defineRule({ id: 'probe/docs-links', description: 'Links resolve.' }),

--- a/tests/gates/repository-policy.core.test.ts
+++ b/tests/gates/repository-policy.core.test.ts
@@ -135,6 +135,41 @@ test('development and peer links between publishable packages must pin the share
   );
 });
 
+test('internal package dependencies must follow the declared package layers', () => {
+  const clean = snapshot();
+  const findings = evaluateRepositoryPolicy({
+    ...clean,
+    manifests: [
+      manifest('redproof', 'packages/redproof', '1.0.0', {
+        dependencies: { '@redproof/adapter-tck': '1.0.0' },
+      }),
+      manifest('@redproof/adapter-tck', 'packages/adapter-tck', '1.0.0', {
+        peerDependencies: { redproof: '1.0.0' },
+      }),
+      manifest('@redproof/example', 'packages/example', '1.0.0', {
+        dependencies: { redproof: '1.0.0', '@redproof/adapter-tck': '1.0.0' },
+        devDependencies: { '@redproof/adapter-tck': '1.0.0' },
+      }),
+    ],
+  });
+
+  assert.deepEqual(
+    findings
+      .filter(item => item.code === 'internal-package-boundary-violated')
+      .map(item => [item.file, item.message]),
+    [
+      [
+        'packages/redproof/package.json',
+        'redproof must not depend on @redproof/adapter-tck through dependencies.',
+      ],
+      [
+        'packages/example/package.json',
+        '@redproof/example may use @redproof/adapter-tck only through devDependencies.',
+      ],
+    ],
+  );
+});
+
 test('a package entrypoint must match on types, runtime, files, and source', () => {
   const broken = (extra: Partial<ManifestSnapshot['manifest']>) =>
     codes(evaluateRepositoryPolicy(snapshot({ manifests: [manifest('redproof', 'packages/redproof', '1.0.0', extra)] })));


### PR DESCRIPTION
Closes the PR #68 review findings.

- Detects bare and qualified ambient globals in purity scans.
- Validates TCK result shapes and exact expected evidence.
- Ties evidence probes to constructed Adapter Rules.
- Enforces core/TCK/Adapter package dependency boundaries.
- Makes test:adapter-tck work from a clean checkout.
- Updates stale documentation and clarifies the TCK trust boundary.

Verification: 637 tests passed, 5 Gates and 28 Rules passed, full proof portfolio passed, and clean-consumer package verification passed.