### PR TITLE
Explain new npm package bootstrap failures

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,6 +98,53 @@ jobs:
           path: artifacts/*.tgz
           retention-days: 30
 
+      - name: Check npm package readiness
+        if: github.event_name == 'release' || github.event.inputs.dry-run == 'false'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          MISSING_PACKAGES=()
+          for PKG in redproof @redproof/adapter-tck @redproof/eslint @redproof/dependency-cruiser @redproof/stryker @redproof/testing; do
+            if LOOKUP=$(npm view "$PKG" name --json 2>&1); then
+              continue
+            fi
+
+            case "$LOOKUP" in
+              *E404*) MISSING_PACKAGES+=("$PKG") ;;
+              *)
+                echo "::error title=npm registry lookup failed::Could not confirm whether $PKG exists. This is not a package-bootstrap failure."
+                printf '%s\n' "$LOOKUP"
+                exit 1
+                ;;
+            esac
+          done
+
+          if [ "${#MISSING_PACKAGES[@]}" -gt 0 ]; then
+            echo "::error title=New npm package needs bootstrap::These packages do not exist on npm yet: ${MISSING_PACKAGES[*]}"
+            echo
+            echo "Action required before this release can continue:"
+            echo "Run these commands while signed in to npm with package write access and 2FA."
+            echo "1. Download the verified tarballs:"
+            echo "   gh run download ${GITHUB_RUN_ID} --repo schalermthai/redproof --name npm-tarballs-${VERSION} --dir artifacts"
+
+            for PKG in "${MISSING_PACKAGES[@]}"; do
+              TARBALL_STEM="${PKG#@}"
+              TARBALL_STEM="${TARBALL_STEM/\//-}"
+              TARBALL="artifacts/${TARBALL_STEM}-${VERSION}.tgz"
+              echo
+              echo "2. Bootstrap $PKG with the verified tarball:"
+              echo "   npm publish \"$TARBALL\" --access public"
+              echo "3. Authorize this workflow as its trusted publisher:"
+              echo "   npm trust github \"$PKG\" --repo schalermthai/redproof --file publish.yml --allow-publish"
+            done
+
+            echo
+            echo "4. Re-run this workflow. Already-published package versions will be skipped."
+            exit 1
+          fi
+
       - name: Publish to npm
         if: github.event_name == 'release' || github.event.inputs.dry-run == 'false'
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -106,15 +106,15 @@ jobs:
           set -euo pipefail
 
           MISSING_PACKAGES=()
-          for PKG in redproof @redproof/adapter-tck @redproof/eslint @redproof/dependency-cruiser @redproof/stryker @redproof/testing; do
-            if LOOKUP=$(npm view "$PKG" name --json 2>&1); then
+          for READY_PACKAGE in redproof @redproof/adapter-tck @redproof/eslint @redproof/dependency-cruiser @redproof/stryker @redproof/testing; do
+            if LOOKUP=$(npm view "$READY_PACKAGE" name --json 2>&1); then
               continue
             fi
 
             case "$LOOKUP" in
-              *E404*) MISSING_PACKAGES+=("$PKG") ;;
+              *E404*) MISSING_PACKAGES+=("$READY_PACKAGE") ;;
               *)
-                echo "::error title=npm registry lookup failed::Could not confirm whether $PKG exists. This is not a package-bootstrap failure."
+                echo "::error title=npm registry lookup failed::Could not confirm whether $READY_PACKAGE exists. This is not a package-bootstrap failure."
                 printf '%s\n' "$LOOKUP"
                 exit 1
                 ;;
@@ -129,15 +129,15 @@ jobs:
             echo "1. Download the verified tarballs:"
             echo "   gh run download ${GITHUB_RUN_ID} --repo schalermthai/redproof --name npm-tarballs-${VERSION} --dir artifacts"
 
-            for PKG in "${MISSING_PACKAGES[@]}"; do
-              TARBALL_STEM="${PKG#@}"
+            for MISSING_PACKAGE in "${MISSING_PACKAGES[@]}"; do
+              TARBALL_STEM="${MISSING_PACKAGE#@}"
               TARBALL_STEM="${TARBALL_STEM/\//-}"
               TARBALL="artifacts/${TARBALL_STEM}-${VERSION}.tgz"
               echo
-              echo "2. Bootstrap $PKG with the verified tarball:"
+              echo "2. Bootstrap $MISSING_PACKAGE with the verified tarball:"
               echo "   npm publish \"$TARBALL\" --access public"
               echo "3. Authorize this workflow as its trusted publisher:"
-              echo "   npm trust github \"$PKG\" --repo schalermthai/redproof --file publish.yml --allow-publish"
+              echo "   npm trust github \"$MISSING_PACKAGE\" --repo schalermthai/redproof --file publish.yml --allow-publish"
             done
 
             echo

--- a/gates/support/repository-policy-model.ts
+++ b/gates/support/repository-policy-model.ts
@@ -86,6 +86,7 @@ function workflowShellRuns(workflow: string, command: string): boolean {
 }
 
 function packageInventory(snapshot: RepositorySnapshot): RepositoryPolicyFinding[] {
+  const readinessLoop = /for READY_PACKAGE in\s+([^;]+);/.exec(snapshot.publishWorkflow)?.[1]?.split(/\s+/) ?? [];
   const publishLoop = /for PKG in\s+([^;]+);/.exec(snapshot.publishWorkflow)?.[1]?.split(/\s+/) ?? [];
   const findings: RepositoryPolicyFinding[] = [];
 
@@ -106,6 +107,11 @@ function packageInventory(snapshot: RepositorySnapshot): RepositoryPolicyFinding
         file: 'scripts/verify-package.ts',
         ok: new RegExp(`name:\\s*['\"]${escaped(pkg.name)}['\"]`).test(snapshot.verifyPackageSource),
         stage: 'package verifier',
+      },
+      {
+        file: '.github/workflows/publish.yml',
+        ok: readinessLoop.includes(pkg.name),
+        stage: 'npm package readiness check',
       },
       {
         file: '.github/workflows/publish.yml',

--- a/tests/gates/checks.test.ts
+++ b/tests/gates/checks.test.ts
@@ -206,7 +206,7 @@ async function seedRepository(root: string, extra: Readonly<Record<string, strin
     'scripts/set-version.ts': "const dirs = ['packages/redproof'];\n",
     'scripts/verify-package.ts': "const packages = [{ name: 'redproof' }];\n",
     '.github/workflows/ci.yml': ciWorkflow,
-    '.github/workflows/publish.yml': `${publishWorkflow}TARBALL="artifacts/redproof-\${VERSION}.tgz"\nfor PKG in redproof; do\nnpm publish "$TARBALL" --tag "$NPM_TAG"\n`,
+    '.github/workflows/publish.yml': `${publishWorkflow}for READY_PACKAGE in redproof; do\nTARBALL="artifacts/redproof-\${VERSION}.tgz"\nfor PKG in redproof; do\nnpm publish "$TARBALL" --tag "$NPM_TAG"\n`,
     'README.md': '[docs](docs/guide.md)\n',
     'docs/guide.md': '# Guide\n',
     ...extra,

--- a/tests/gates/repository-policy.core.test.ts
+++ b/tests/gates/repository-policy.core.test.ts
@@ -52,6 +52,7 @@ function snapshot(overrides: Partial<RepositorySnapshot> = {}): RepositorySnapsh
     ciWorkflow,
     publishWorkflow: [
       publishWorkflow,
+      'for READY_PACKAGE in redproof; do',
       'TARBALL="artifacts/redproof-${VERSION}.tgz"',
       'for PKG in redproof; do',
       'npm publish "$TARBALL" --tag "$NPM_TAG"',
@@ -85,6 +86,7 @@ test('a package missing from any release stage is reported once per stage, again
     ['packageInventory', 'package-missing-from-release-stage', 'package.json', '@redproof/extra is missing from the root build script.'],
     ['packageInventory', 'package-missing-from-release-stage', 'scripts/set-version.ts', '@redproof/extra is missing from the version setter.'],
     ['packageInventory', 'package-missing-from-release-stage', 'scripts/verify-package.ts', '@redproof/extra is missing from the package verifier.'],
+    ['packageInventory', 'package-missing-from-release-stage', '.github/workflows/publish.yml', '@redproof/extra is missing from the npm package readiness check.'],
     ['packageInventory', 'package-missing-from-release-stage', '.github/workflows/publish.yml', '@redproof/extra is missing from the verified tarball publish.'],
     ['packageInventory', 'package-missing-from-release-stage', '.github/workflows/publish.yml', '@redproof/extra is missing from the publish loop.'],
     ['publicFiles', 'invalid-package-entrypoint', 'packages/extra/package.json', '@redproof/extra must declare matching runtime and type entrypoints backed by source.'],
@@ -101,6 +103,7 @@ test('a second package is accepted once every release stage names it', () => {
     verifyPackageSource: "const packages = [{ name: 'redproof' }, { name: \"@redproof/extra\" }];",
     publishWorkflow: [
       publishWorkflow,
+      'for READY_PACKAGE in redproof @redproof/extra; do',
       'TARBALL="artifacts/redproof-${VERSION}.tgz"',
       'TARBALL="artifacts/redproof-extra-${VERSION}.tgz"',
       'for PKG in redproof @redproof/extra; do',
@@ -318,6 +321,26 @@ test('publishing must name the verified tarball for every package', () => {
 
   assert.deepEqual(findings.map(item => [item.code, item.message]), [
     ['package-missing-from-release-stage', 'redproof is missing from the verified tarball publish.'],
+  ]);
+});
+
+test('npm readiness and publication inventories are enforced independently', () => {
+  const clean = snapshot();
+
+  const missingFromReadiness = evaluateRepositoryPolicy({
+    ...clean,
+    publishWorkflow: clean.publishWorkflow.replace('for READY_PACKAGE in redproof;', 'for READY_PACKAGE in redproof-off;'),
+  });
+  assert.deepEqual(missingFromReadiness.map(item => item.message), [
+    'redproof is missing from the npm package readiness check.',
+  ]);
+
+  const missingFromPublish = evaluateRepositoryPolicy({
+    ...clean,
+    publishWorkflow: clean.publishWorkflow.replace('for PKG in redproof;', 'for PKG in redproof-off;'),
+  });
+  assert.deepEqual(missingFromPublish.map(item => item.message), [
+    'redproof is missing from the publish loop.',
   ]);
 });
 


### PR DESCRIPTION
## What changes

- Adds an npm package-readiness preflight after verified tarballs are uploaded and before publication begins.
- Checks every release package by name, so an unpublished package is discovered before any package version from the release is published.
- Treats npm `E404` as a one-time package-bootstrap requirement.
- Prints copyable commands to download the verified workflow artifact, publish the first public version, configure this GitHub workflow with `npm trust`, and rerun the release.
- Reports registry or network failures separately instead of incorrectly telling maintainers to bootstrap a package.

## Claims

### A missing npm package cannot create a surprise partial release

The readiness loop checks the complete package inventory before the existing publish loop starts. If one or more package names do not exist, the workflow stops before publishing any of the other package versions.

### The failure is actionable

The verified tarballs have already been uploaded when readiness is checked. The error identifies every missing package and prints commands containing the actual workflow run ID, release version, tarball filename, repository, workflow filename, and package name. After the maintainer completes the one-time first publish and trusted-publisher setup, the resumable workflow can be rerun; versions already published manually are skipped.

### Registry failures are not disguised as bootstrap work

Only an npm `E404` is classified as a missing package. Other failures retain npm output and use a distinct `npm registry lookup failed` annotation.

### The security boundary remains human-controlled

This does not automate the first publication or creation of an npm Trusted Publisher. The maintainer still authenticates with package write access and 2FA. This change only makes that required action clear and repeatable.

## Verification

- Simulated an `E404` for `@redproof/adapter-tck` and verified the rendered `gh run download`, `npm publish`, `npm trust`, and rerun guidance.
- Simulated an npm `ETIMEDOUT` failure and verified that it reports a registry lookup failure without bootstrap instructions.
- Parsed the workflow as YAML and checked the extracted readiness script with `bash -n`.
- `npm run self:check`: all 5 Gates and 28 Rules passed.
- `git diff --check` passed.