### PR TITLE
Harden ESLint adapter evidence handling

### DIFF
--- a/packages/eslint/src/index.ts
+++ b/packages/eslint/src/index.ts
@@ -10,7 +10,11 @@ import {
   type Rule,
   rejectUnknownKeys,
 } from 'redproof';
-import { eslintBreaches, fatalEslintDiagnostic } from './model.ts';
+import {
+  eslintBreaches,
+  fatalEslintDiagnostic,
+  incompleteEslintDiagnostic,
+} from './model.ts';
 
 type EslintRuleInput = Readonly<Record<string, string>>;
 
@@ -81,6 +85,14 @@ export function eslint<const O extends EslintAdapterOptions<EslintRuleInput>>(
           const engine = new ESLint({
             cwd: ctx.root,
             overrideConfig: {
+              languageOptions: {
+                parserOptions: {
+                  // ESLint's `cwd` does not become the parser's project root.
+                  // Keep project-aware parsers (for example TypeScript) inside
+                  // the Gate workspace when a check runs from a copy.
+                  tsconfigRootDir: ctx.root,
+                },
+              },
               rules: Object.fromEntries(
                 Object.values(options.rules).map(ruleId => [ruleId, 'error']),
               ),
@@ -98,6 +110,9 @@ export function eslint<const O extends EslintAdapterOptions<EslintRuleInput>>(
 
           const fatal = fatalEslintDiagnostic(ctx.root, lintResults);
           if (fatal) return result.refuse(scan, fatal);
+
+          const incomplete = incompleteEslintDiagnostic(ctx.root, lintResults);
+          if (incomplete) return result.refuse(scan, incomplete);
 
           return result.fromBreaches(scan, eslintBreaches(ctx.root, lintResults, byForeignId));
         } catch (error) {

--- a/packages/eslint/src/model.ts
+++ b/packages/eslint/src/model.ts
@@ -18,6 +18,7 @@ export type EslintMessage = {
 export type EslintResult = {
   readonly filePath: string;
   readonly messages: readonly EslintMessage[];
+  readonly suppressedMessages?: readonly EslintMessage[] | undefined;
 };
 
 export function eslintDiagnostic(root: string, file: string, message: EslintMessage): Diagnostic {
@@ -43,6 +44,22 @@ export function fatalEslintDiagnostic(
   return null;
 }
 
+export function incompleteEslintDiagnostic(
+  root: string,
+  results: readonly EslintResult[],
+): Diagnostic | null {
+  for (const result of results) {
+    const incomplete = result.messages.find(message => !message.ruleId && !message.fatal);
+    if (incomplete) {
+      return {
+        ...eslintDiagnostic(root, result.filePath, incomplete),
+        code: 'eslint-incomplete-evidence',
+      };
+    }
+  }
+  return null;
+}
+
 export function eslintBreaches<R extends RuleRef>(
   root: string,
   results: readonly EslintResult[],
@@ -51,7 +68,10 @@ export function eslintBreaches<R extends RuleRef>(
   const breaches: Breach<R>[] = [];
 
   for (const result of results) {
-    for (const message of result.messages) {
+    for (const message of [
+      ...result.messages,
+      ...(result.suppressedMessages ?? []),
+    ]) {
       if (!message.ruleId) continue;
       const rule = byForeignId.get(message.ruleId);
       if (!rule) continue;

--- a/tests/adapters/adapter-contracts.structured.test.ts
+++ b/tests/adapters/adapter-contracts.structured.test.ts
@@ -44,6 +44,16 @@ test('structured: every Adapter creates Breaches only from selected structured f
   );
   assert.equal(eslintFindings[0]?.location?.file, 'src/a.ts');
 
+  const suppressed = eslintBreaches('/repo', [{
+    filePath: '/repo/src/a.ts',
+    messages: [],
+    suppressedMessages: [{ ruleId: 'semi', message: 'Suppressed semicolon.', line: 3, column: 1 }],
+  }], new Map<string, Rule>([['semi', eslintRule]]));
+  assert.deepEqual(
+    suppressed.map(item => [item.rule, item.message, item.location?.line]),
+    [['eslint/semi', 'Suppressed semicolon.', 3]],
+  );
+
   const dependencyFindings: DependencyCruiserViolation[] = [
     { from: 'src/a.ts', to: 'src/b.ts', rule: { name: 'no-cycles' } },
     { from: 'src/a.ts', to: 'src/c.ts', rule: { name: 'not-selected' } },

--- a/tests/adapters/eslint.test.ts
+++ b/tests/adapters/eslint.test.ts
@@ -89,6 +89,88 @@ test('one run reports breaches of every adopted Rule, and clean source passes', 
   });
 });
 
+test('project-aware parsers resolve their project from the Gate root', async () => {
+  await withWorkspace(async root => {
+    await write(root, 'eslint.config.mjs', `import { realpathSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = dirname(fileURLToPath(import.meta.url));
+const parser = {
+  parse(source, options) {
+    if (realpathSync(options.tsconfigRootDir) !== realpathSync(root)) {
+      throw new Error('parser project root does not match the Gate root');
+    }
+    return {
+      type: 'Program',
+      body: [],
+      sourceType: 'module',
+      range: [0, source.length],
+      loc: {
+        start: { line: 1, column: 0 },
+        end: { line: 1, column: source.length },
+      },
+      tokens: [],
+      comments: [],
+    };
+  },
+};
+
+export default [{
+  files: ['**/*.js'],
+  languageOptions: { parser },
+  rules: {},
+}];
+`);
+    await write(root, 'src/clean.js', '');
+
+    const result = await run(root, ['src/clean.js']);
+
+    assert.equal(result.verdict, 'pass', JSON.stringify(result));
+  });
+});
+
+test('a selected Rule remains a Breach when ESLint reports it as suppressed', async () => {
+  await withWorkspace(async root => {
+    await write(root, 'eslint.config.mjs', FLAT_CONFIG);
+    await write(
+      root,
+      'src/suppressed.js',
+      '/* eslint-disable no-console */\nconsole.log(1);\n/* eslint-enable no-console */\n',
+    );
+
+    const result = await run(root, ['src/suppressed.js']);
+
+    assert.equal(result.verdict, 'fail');
+    if (result.verdict !== 'fail') return;
+    assert.equal(result.breaches.length, 1);
+    assert.equal(result.breaches[0]?.rule, 'eslint/no-console');
+    assert.equal(result.breaches[0]?.code, 'no-console');
+  });
+});
+
+test('an explicitly ignored target REFUSES as incomplete evidence', async () => {
+  await withWorkspace(async root => {
+    await write(root, 'eslint.config.mjs', `export default [
+  { ignores: ['src/ignored.js'] },
+  {
+    files: ['**/*.js'],
+    languageOptions: { ecmaVersion: 'latest', sourceType: 'module' },
+    rules: {},
+  },
+];
+`);
+    await write(root, 'src/ignored.js', 'console.log(1);\n');
+
+    const result = await run(root, ['src/ignored.js']);
+
+    assert.equal(result.verdict, 'refuse');
+    if (result.verdict !== 'refuse') return;
+    assert.equal(result.why.code, 'eslint-incomplete-evidence');
+    assert.equal(result.why.location?.file, 'src/ignored.js');
+  });
+});
+
 test('an ESLint finding the Gate did not adopt is not a Breach of anything', async () => {
   await withWorkspace(async root => {
     await write(root, 'eslint.config.mjs', `export default [


### PR DESCRIPTION
## Summary

Hardens `@redproof/eslint` based on discrepancies found while wrapping ESLint 10.10.0's own dogfood with Redproof.

The adapter API remains unchanged. This PR changes how the adapter establishes and interprets ESLint evidence.

## Claims

### C1: Project-aware parsers resolve projects from the Gate workspace

The adapter now supplies `parserOptions.tsconfigRootDir` from `ctx.root`. A parser used while checking an isolated proof copy therefore resolves its project from that copy, rather than from the Redproof worker's process directory.

Evidence:

- A repository regression parser refuses unless its canonical project root equals the Gate root.
- ESLint's real `expect-type/expect` dogfood passed through `@typescript-eslint/parser` in copies mode after this change.

### C2: Source suppressions cannot hide an adopted Redproof Rule

Selected findings from ESLint's `suppressedMessages` now become targeted Breaches just like selected findings from `messages`.

Evidence:

- A pure-model contract proves suppressed structured evidence maps to the adopted Rule.
- An integration test proves `/* eslint-disable no-console */` no longer turns an adopted `no-console` guardrail into PASS.
- The external ESLint proof reproduced the same failure with `no-alert` before the fix and passed after it.

### C3: A requested target that ESLint did not inspect cannot produce PASS

Nonfatal ESLint diagnostics without a Rule id now return REFUSE with `eslint-incomplete-evidence`. This covers ignored files and files for which no matching configuration was supplied.

Evidence:

- An integration test explicitly requests an ignored file and requires REFUSE with its relative location.
- ESLint's own ignored fixture produced a false PASS before the fix and the expected REFUSE after it.

### C4: Existing adapter configuration remains source-compatible

No package export, adapter option, or TypeScript signature changed. Existing `eslint({ files, rules })` configurations continue to compile. The observable change is limited to cases that previously produced false PASS or an incorrect parser-root REFUSE.

## Size

- 4 files changed
- 129 insertions, 2 deletions
- 37 production additions and 92 test additions

## Verification

- `npm run build`
- `npm run typecheck`
- `npm run test:adapters` — 215 tests passed
- `npm run self:check` — 5 Gates and 28 Rules passed
- External ESLint 10.10.0 portfolio — 9 dogfood Gates passed; RED/GREEN proofs passed across core Rules, configured Rules, local and external plugins, JSON, YAML, TypeScript, full-workspace linting, and the native command boundary
