### PR TITLE
Harden dependency-cruiser evidence handling

### DIFF
--- a/packages/dependency-cruiser/README.md
+++ b/packages/dependency-cruiser/README.md
@@ -46,6 +46,10 @@ baseline. Matching known violations are ignored; new violations still breach
 their selected Redproof Rules. Checks run without dependency-cruiser caching so
 proof mutations cannot reuse stale architecture results.
 
+Every selected dependency-cruiser Rule must also be active. A Rule configured
+with severity `ignore` produces REFUSE, because Redproof cannot honestly claim
+that an architecture boundary holds when dependency-cruiser has disabled it.
+
 A baseline weakens the Gate on purpose. Keep a RED proof that plants a new
 violation, so the Gate is known to still fail. A baseline that grows with every
 new violation guards nothing and still reports PASS. A baseline file that is not

--- a/packages/dependency-cruiser/src/index.ts
+++ b/packages/dependency-cruiser/src/index.ts
@@ -12,7 +12,9 @@ import {
   rejectUnknownKeys,
 } from 'redproof';
 import {
+  dependencyCruiserRuleAvailability,
   violationsToBreaches,
+  type DependencyCruiserConfig,
   type DependencyCruiserViolation,
 } from './model.ts';
 
@@ -50,12 +52,6 @@ type PackageManifest = {
   readonly exports?: Readonly<Record<string, PackageExport>>;
 };
 
-type DependencyCruiserConfig = {
-  readonly forbidden?: readonly { readonly name?: string }[];
-  readonly required?: readonly { readonly name?: string }[];
-  readonly allowed?: readonly unknown[];
-};
-
 type CruiseOutputLike = {
   readonly summary?: {
     readonly totalCruised?: number;
@@ -80,14 +76,6 @@ function readCruiseOutput(output: unknown): CruiseOutputLike | null {
 
 function now(): string {
   return new Date().toISOString();
-}
-
-function configuredRuleNames(config: DependencyCruiserConfig): ReadonlySet<string> {
-  return new Set([
-    ...(config.forbidden ?? []).flatMap(rule => rule.name ? [rule.name] : []),
-    ...(config.required ?? []).flatMap(rule => rule.name ? [rule.name] : []),
-    ...((config.allowed?.length ?? 0) > 0 ? ['not-in-allowed'] : []),
-  ]);
 }
 
 function withCwd<T>(root: string, action: () => Promise<T>): Promise<T> {
@@ -236,10 +224,12 @@ export function dependencyCruiser<
             const dependencyCruiser = await loadDependencyCruiser(ctx.root);
             const configPath = resolve(ctx.root, configFile);
             const config = await dependencyCruiser.extractConfig(configPath) as DependencyCruiserConfig;
-            const available = configuredRuleNames(config);
-            const missing = Object.values(options.rules).filter(name => !available.has(name));
+            const availability = dependencyCruiserRuleAvailability(
+              config,
+              Object.values(options.rules),
+            );
 
-            if (missing.length > 0) {
+            if (availability.missing.length > 0) {
               return result.refuse(
                 {
                   source: 'dependency-cruiser',
@@ -251,7 +241,24 @@ export function dependencyCruiser<
                   code: 'dependency-cruiser-rule-missing',
                   message: 'Configured Redproof rules are missing from the dependency-cruiser configuration.',
                   location: { file: configFile, line: null, column: null },
-                  detail: `Missing: ${missing.join(', ')}`,
+                  detail: `Missing: ${availability.missing.join(', ')}`,
+                },
+              );
+            }
+
+            if (availability.inactive.length > 0) {
+              return result.refuse(
+                {
+                  source: 'dependency-cruiser',
+                  startedAt,
+                  finishedAt: now(),
+                  inspected: null,
+                },
+                {
+                  code: 'dependency-cruiser-rule-inactive',
+                  message: 'Configured Redproof rules are disabled in the dependency-cruiser configuration.',
+                  location: { file: configFile, line: null, column: null },
+                  detail: `Inactive: ${availability.inactive.join(', ')}`,
                 },
               );
             }

--- a/packages/dependency-cruiser/src/model.ts
+++ b/packages/dependency-cruiser/src/model.ts
@@ -13,15 +13,51 @@ export type DependencyCruiserViolation = {
     readonly name: string;
     readonly severity?: string;
   };
-  readonly cycle?: readonly string[];
-  readonly via?: readonly string[];
+  readonly cycle?: readonly DependencyCruiserRouteEntry[];
+  readonly via?: readonly DependencyCruiserRouteEntry[];
 };
+
+export type DependencyCruiserRouteEntry = string | {
+  readonly name: string;
+  readonly dependencyTypes?: readonly string[];
+};
+
+export type DependencyCruiserConfig = {
+  readonly forbidden?: readonly DependencyCruiserRuleDefinition[];
+  readonly required?: readonly DependencyCruiserRuleDefinition[];
+  readonly allowed?: readonly unknown[];
+};
+
+type DependencyCruiserRuleDefinition = {
+  readonly name?: string;
+  readonly severity?: string;
+};
+
+export function dependencyCruiserRuleAvailability(
+  config: DependencyCruiserConfig,
+  selected: readonly string[],
+): { readonly missing: readonly string[]; readonly inactive: readonly string[] } {
+  const configured = new Map<string, string | undefined>();
+  for (const rule of [...(config.forbidden ?? []), ...(config.required ?? [])]) {
+    if (rule.name) configured.set(rule.name, rule.severity);
+  }
+  if ((config.allowed?.length ?? 0) > 0) configured.set('not-in-allowed', undefined);
+
+  return {
+    missing: selected.filter(name => !configured.has(name)),
+    inactive: selected.filter(name => configured.get(name) === 'ignore'),
+  };
+}
+
+function routeName(entry: DependencyCruiserRouteEntry): string {
+  return typeof entry === 'string' ? entry : entry.name;
+}
 
 export function violationDiagnostic(violation: DependencyCruiserViolation): Diagnostic {
   const route = violation.cycle?.length
-    ? `Cycle: ${violation.cycle.join(' -> ')}`
+    ? `Cycle: ${violation.cycle.map(routeName).join(' -> ')}`
     : violation.via?.length
-      ? `Via: ${violation.via.join(' -> ')}`
+      ? `Via: ${violation.via.map(routeName).join(' -> ')}`
       : undefined;
 
   return {
@@ -43,6 +79,7 @@ export function violationsToBreaches<R extends RuleRef>(
   const breaches: Breach<R>[] = [];
 
   for (const violation of violations) {
+    if (violation.rule.severity === 'ignore') continue;
     const rule = byForeignRule.get(violation.rule.name);
     if (!rule) continue;
     breaches.push(breach(rule, violationDiagnostic(violation)));

--- a/tests/adapters/dependency-cruiser.test.ts
+++ b/tests/adapters/dependency-cruiser.test.ts
@@ -163,13 +163,34 @@ test('a Rule the dependency-cruiser configuration does not define REFUSES instea
   });
 });
 
+test('a Rule disabled in dependency-cruiser REFUSES instead of falsely passing', async () => {
+  await withWorkspace(async root => {
+    await writeFakeDependencyCruiser(root, {
+      config: "export default async function extractConfig() { return { forbidden: [{ name: 'no-new-debt', severity: 'ignore' }] }; }\n",
+      cruise: "export async function cruise() { throw new Error('cruise must not run'); }\n",
+    });
+
+    const result = await run(adapterFor({}), root);
+
+    assert.equal(result.verdict, 'refuse');
+    if (result.verdict !== 'refuse') return;
+    assert.equal(result.why.code, 'dependency-cruiser-rule-inactive');
+    assert.equal(result.why.location?.file, '.dependency-cruiser.mjs');
+    assert.match(result.why.detail ?? '', /no-new-debt/u);
+    assert.equal(result.scan.inspected, null);
+  });
+});
+
 test('a known-violations baseline is forwarded to dependency-cruiser, and new violations still fail', async () => {
   await withWorkspace(async root => {
     await writeFakeDependencyCruiser(root, {
       cruise: cruiseReporting(`{
-    totalCruised: 3,
+    totalCruised: 4,
     violations: (options.ignoreKnown === true && options.knownViolations.length === 1)
-      ? [{ rule: { name: 'no-new-debt', severity: 'error' }, from: 'src/a.ts', to: 'src/b.ts' }]
+      ? [
+          { rule: { name: 'no-new-debt', severity: 'ignore' }, from: 'src/known.ts', to: 'src/debt.ts' },
+          { rule: { name: 'no-new-debt', severity: 'error' }, from: 'src/a.ts', to: 'src/b.ts' },
+        ]
       : [{ rule: { name: 'no-new-debt' }, from: 'baseline', to: 'was not forwarded' }],
   }`),
     });
@@ -183,6 +204,7 @@ test('a known-violations baseline is forwarded to dependency-cruiser, and new vi
 
     assert.equal(result.verdict, 'fail');
     if (result.verdict !== 'fail') return;
+    assert.equal(result.breaches.length, 1);
     assert.equal(result.breaches[0]?.location?.file, 'src/a.ts');
   });
 });

--- a/tests/adapters/dependency-cruiser.violations.core.test.ts
+++ b/tests/adapters/dependency-cruiser.violations.core.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import type { Rule } from 'redproof';
 import {
+  dependencyCruiserRuleAvailability,
   violationDiagnostic,
   violationsToBreaches,
   type DependencyCruiserViolation,
@@ -29,6 +30,31 @@ const violation = (
   to: 'src/infrastructure/database.ts',
   rule: { name, severity: 'error' },
   ...extra,
+});
+
+test('rule availability distinguishes active, inactive, and missing configuration', () => {
+  assert.deepEqual(
+    dependencyCruiserRuleAvailability({
+      forbidden: [
+        { name: 'active-error', severity: 'error' },
+        { name: 'active-warn', severity: 'warn' },
+        { name: 'inactive', severity: 'ignore' },
+      ],
+      required: [{ name: 'active-info', severity: 'info' }],
+      allowed: [{ from: {}, to: {} }],
+    }, [
+      'active-error',
+      'active-warn',
+      'active-info',
+      'not-in-allowed',
+      'inactive',
+      'absent',
+    ]),
+    {
+      missing: ['absent'],
+      inactive: ['inactive'],
+    },
+  );
 });
 
 test('each adopted violation becomes a Breach of the Redproof Rule that maps to it', () => {
@@ -65,6 +91,17 @@ test('a violation of a rule the Gate did not adopt produces no Breach', () => {
     violation('domain-no-infrastructure'),
   ], byForeignRule);
   assert.deepEqual(mixed.map(item => item.rule), [domain.id]);
+});
+
+test('a known violation softened to ignore does not become a Redproof Breach', () => {
+  assert.deepEqual(
+    violationsToBreaches([
+      violation('domain-no-infrastructure', {
+        rule: { name: 'domain-no-infrastructure', severity: 'ignore' },
+      }),
+    ], byForeignRule),
+    [],
+  );
 });
 
 test('a Breach names the dependency that broke the rule and where it starts', () => {
@@ -113,6 +150,18 @@ test('an indirect breach carries the route that produced it', () => {
     })).detail,
     'Cycle: src/a.ts -> src/b.ts',
     'a cycle is the more precise route, so it wins over via',
+  );
+});
+
+test('a structured cycle names its modules instead of stringifying its objects', () => {
+  assert.equal(
+    violationDiagnostic(violation('no-cycles', {
+      cycle: [
+        { name: 'src/a.ts', dependencyTypes: ['local', 'import'] },
+        { name: 'src/b.ts', dependencyTypes: ['local', 'import'] },
+      ],
+    })).detail,
+    'Cycle: src/a.ts -> src/b.ts',
   );
 });
 


### PR DESCRIPTION
Battle-tested against dependency-cruiser's own architecture dogfood on its latest main.

Claims:

- A selected dependency-cruiser Rule configured with severity `ignore` can no longer produce a false PASS; the Adapter REFUSES with a targeted `dependency-cruiser-rule-inactive` diagnostic before cruising.
- Known violations softened by dependency-cruiser to severity `ignore` no longer become Redproof Breaches, while new violations of the same selected Rule still fail.
- Structured `cycle` and `via` entries render their module names instead of `[object Object]`.
- Rule-availability and evidence translation remain in the functional core; the Adapter shell owns configuration loading and REFUSE construction.
- The behavior for inactive selected Rules is documented.

Expert-dogfood evidence:

- dependency-cruiser native oracle: 572 modules and 1,606 dependencies cruised; 26 known violations accepted.
- Redproof upstream portfolio: 6 Gates and 10 Rules passed.
- All 16 upstream RED/GREEN proofs passed and restored cleanly.
- The disabled-Rule native control reported the exact planted `not-outside` edge when enabled.
- The baseline proof ignored existing debt and reported only the newly planted `cli-to-main-only` edge.
- The cycle proof reported `src/main/index.mjs -> src/main/cruise.mjs`.

Repository verification:

- TypeScript typecheck passed.
- 219/219 Adapter and TCK tests passed.
- 650/650 full repository tests passed.
- Self-check passed: 5 Gates and 28 Rules.
- Complete self-proof portfolio passed.