### PR TITLE
Harden Stryker adapter reporting

### DIFF
--- a/packages/stryker/README.md
+++ b/packages/stryker/README.md
@@ -84,6 +84,12 @@ undetected mutant without a stable identity refuses, and no other Rule is
 evaluated in that run. The `replacement` text comes from Stryker's code
 generator, so a Stryker upgrade can change it and make entries stale.
 
+The Adapter disables Stryker's reporters and logs while it runs. This keeps
+Redproof's text, JSON, and SARIF output as the only reporting stream. A Stryker
+failure is returned as REFUSE detail; rerun Stryker directly when you need its
+native debug log or mutation report. Mutant and baseline locations are reported
+relative to the Gate root, even when Stryker runs from a nested `cwd`.
+
 Then run:
 
 ```bash

--- a/packages/stryker/src/baseline.ts
+++ b/packages/stryker/src/baseline.ts
@@ -37,6 +37,29 @@ export type StrykerBaselineAssessment =
       readonly detail: string;
     };
 
+/** Make producer paths stable and meaningful after a Redproof Gate copy is released. */
+export function relativizeStrykerMutants(
+  gateRoot: string,
+  workingDirectory: string,
+  mutants: readonly StrykerMutantResult[],
+): readonly StrykerMutantResult[] {
+  const absoluteGateRoot = resolve(gateRoot);
+  const absoluteWorkingDirectory = resolve(workingDirectory);
+
+  return mutants.map((mutant) => {
+    if (!mutant.fileName) return mutant;
+    const absoluteFile = isAbsolute(mutant.fileName)
+      ? resolve(mutant.fileName)
+      : resolve(absoluteWorkingDirectory, mutant.fileName);
+    const relativeFile = relative(absoluteGateRoot, absoluteFile);
+    if (relativeFile === '' || relativeFile === '..'
+      || relativeFile.startsWith(`..${sep}`) || isAbsolute(relativeFile)) {
+      return mutant;
+    }
+    return { ...mutant, fileName: relativeFile.split(sep).join('/') };
+  });
+}
+
 function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/packages/stryker/src/index.ts
+++ b/packages/stryker/src/index.ts
@@ -1,6 +1,6 @@
 import { Stryker } from '@stryker-mutator/core';
 import { readFile, realpath } from 'node:fs/promises';
-import { isAbsolute, resolve } from 'node:path';
+import { isAbsolute, relative, resolve, sep } from 'node:path';
 import {
   counting,
   defineAdapter,
@@ -18,12 +18,14 @@ import {
 import {
   assessStrykerBaseline,
   parseAcceptedStrykerMutants,
+  relativizeStrykerMutants,
   type AcceptedStrykerMutant,
   type StrykerBaselineAssessment,
 } from './baseline.ts';
 import {
   mutationMetrics,
   mutationScoreBreach,
+  strykerProgrammaticOptions,
   undetectedMutantBreaches,
   type StrykerMutantResult,
 } from './model.ts';
@@ -32,7 +34,7 @@ import { confineCanonicalStrykerCwd, resolveStrykerCwd } from './cwd.ts';
 export type StrykerRuleOptions = {
   readonly mutantsDetected?: true;
   readonly noNewUndetectedMutants?: {
-    /** JSON baseline path relative to the Gate root. */
+    /** JSON baseline path relative to the Stryker working directory. */
     readonly acceptedMutantsFile: string;
   };
   readonly mutationScore?: {
@@ -73,6 +75,10 @@ function cwdOutsideRoot(startedAt: string, path: string) {
     location: null,
     detail: path,
   });
+}
+
+function projectRelativeFile(root: string, absoluteFile: string): string {
+  return relative(root, absoluteFile).split(sep).join('/');
 }
 
 type LoadedBaseline =
@@ -220,8 +226,10 @@ export function stryker<const O extends StrykerAdapterOptions<StrykerRuleOptions
 
           return await withCwd(workingDirectory.path, async () => withoutTestRunnerEnv(async () => {
             let acceptedMutants: readonly AcceptedStrykerMutant[] | undefined;
+            let acceptedMutantsLocationFile: string | undefined;
             const acceptedMutantsFile = options.rules.noNewUndetectedMutants?.acceptedMutantsFile;
             if (acceptedMutantsFile) {
+              const baselinePath = resolve(workingDirectory.path, acceptedMutantsFile);
               const loaded = await loadAcceptedMutants(canonicalRoot, workingDirectory.path, acceptedMutantsFile);
               if (loaded.kind === 'outside') {
                 return refuseBeforeRun(startedAt, {
@@ -231,29 +239,35 @@ export function stryker<const O extends StrykerAdapterOptions<StrykerRuleOptions
                   detail: loaded.path,
                 });
               }
+              acceptedMutantsLocationFile = projectRelativeFile(canonicalRoot, baselinePath);
               if (loaded.kind === 'invalid') {
                 return refuseBeforeRun(startedAt, {
                   code: 'stryker-accepted-mutants-invalid',
                   message: 'The accepted-mutants baseline could not be read.',
-                  location: { file: acceptedMutantsFile, line: null, column: null },
+                  location: { file: acceptedMutantsLocationFile, line: null, column: null },
                   detail: loaded.detail,
                 });
               }
               acceptedMutants = loaded.accepted;
             }
 
-            const engine = new Stryker({
-              ...(configFile ? { configFile } : {}),
-              reporters: [],
-              cleanTempDir: 'always',
-            });
-            const mutants = await engine.runMutationTest() as readonly StrykerMutantResult[];
-            const metrics = mutationMetrics(mutants);
+            // Stryker's generated type uses a nominal string enum for values
+            // that its public configuration schema accepts as string literals.
+            const engine = new Stryker(
+              strykerProgrammaticOptions(configFile) as ConstructorParameters<typeof Stryker>[0],
+            );
+            const producerMutants = await engine.runMutationTest() as readonly StrykerMutantResult[];
+            const mutants = relativizeStrykerMutants(
+              canonicalRoot,
+              workingDirectory.path,
+              producerMutants,
+            );
+            const metrics = mutationMetrics(producerMutants);
             const scan = {
               source: 'stryker',
               startedAt,
               finishedAt: now(),
-              inspected: mutants.length,
+              inspected: producerMutants.length,
             } as const;
 
             if (metrics.pending > 0) {
@@ -274,14 +288,14 @@ export function stryker<const O extends StrykerAdapterOptions<StrykerRuleOptions
             }
 
             const baseline = acceptedMutants
-              ? assessStrykerBaseline(workingDirectory.path, mutants, acceptedMutants)
+              ? assessStrykerBaseline(workingDirectory.path, producerMutants, acceptedMutants)
               : undefined;
             if (baseline?.kind === 'invalid') {
               return result.refuse(scan, {
                 code: baseline.code,
                 message: BASELINE_INVALID_MESSAGES[baseline.code],
-                location: acceptedMutantsFile
-                  ? { file: acceptedMutantsFile, line: null, column: null }
+                location: acceptedMutantsLocationFile
+                  ? { file: acceptedMutantsLocationFile, line: null, column: null }
                   : null,
                 detail: baseline.detail,
               });
@@ -298,7 +312,11 @@ export function stryker<const O extends StrykerAdapterOptions<StrykerRuleOptions
 
             if (options.rules.noNewUndetectedMutants && baseline?.kind === 'compared') {
               breaches.push(...undetectedMutantBreaches(
-                baseline.newUndetected,
+                relativizeStrykerMutants(
+                  canonicalRoot,
+                  workingDirectory.path,
+                  baseline.newUndetected,
+                ),
                 rulesByAlias.noNewUndetectedMutants!,
                 'outside the accepted baseline',
               ));

--- a/packages/stryker/src/model.ts
+++ b/packages/stryker/src/model.ts
@@ -45,6 +45,27 @@ export type MutationMetrics = {
   readonly score: number | null;
 };
 
+export type StrykerProgrammaticOptions = {
+  readonly configFile?: string;
+  readonly reporters: [];
+  readonly cleanTempDir: 'always';
+  readonly logLevel: 'off';
+  readonly fileLogLevel: 'off';
+};
+
+/** Keep Stryker as an evidence producer while Redproof owns the reporting stream. */
+export function strykerProgrammaticOptions(
+  configFile?: string,
+): StrykerProgrammaticOptions {
+  return {
+    ...(configFile ? { configFile } : {}),
+    reporters: [],
+    cleanTempDir: 'always',
+    logLevel: 'off',
+    fileLogLevel: 'off',
+  };
+}
+
 export function mutationMetrics(mutants: readonly StrykerMutantResult[]): MutationMetrics {
   let detected = 0;
   let undetected = 0;

--- a/tests/adapters/stryker.baseline.core.test.ts
+++ b/tests/adapters/stryker.baseline.core.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import {
   assessStrykerBaseline,
   parseAcceptedStrykerMutants,
+  relativizeStrykerMutants,
   strykerMutantIdentity,
   type AcceptedStrykerMutant,
 } from '../../packages/stryker/src/baseline.ts';
@@ -36,6 +37,18 @@ const survivor = (extra: Partial<StrykerMutantResult> = {}): StrykerMutantResult
 });
 
 const parseOne = (entry: unknown) => parseAcceptedStrykerMutants(JSON.stringify([entry]));
+
+test('mutant diagnostics are relative to the Gate root, not a disposable copy or nested cwd', () => {
+  const gateRoot = join('/', 'copies', 'gate-1');
+  const cwd = join(gateRoot, 'packages', 'parser');
+  const [absolute, alreadyRelative] = relativizeStrykerMutants(gateRoot, cwd, [
+    survivor({ fileName: join(cwd, 'src', 'parser.ts') }),
+    survivor({ id: '2', fileName: 'src/scanner.ts' }),
+  ]);
+
+  assert.equal(absolute?.fileName, 'packages/parser/src/parser.ts');
+  assert.equal(alreadyRelative?.fileName, 'packages/parser/src/scanner.ts');
+});
 
 test('a baseline entry is identified by file, span, mutator, and replacement together', () => {
   assert.equal(

--- a/tests/adapters/stryker.metrics.core.test.ts
+++ b/tests/adapters/stryker.metrics.core.test.ts
@@ -3,10 +3,28 @@ import test from 'node:test';
 import {
   mutationMetrics,
   mutationScoreBreach,
+  strykerProgrammaticOptions,
   undetectedMutantBreaches,
   type MutationMetrics,
   type StrykerMutantResult,
 } from '../../packages/stryker/src/model.ts';
+
+test('the programmatic producer cannot write beside the Redproof reporter', () => {
+  assert.deepEqual(strykerProgrammaticOptions('stryker.config.mjs'), {
+    configFile: 'stryker.config.mjs',
+    reporters: [],
+    cleanTempDir: 'always',
+    logLevel: 'off',
+    fileLogLevel: 'off',
+  });
+
+  assert.deepEqual(strykerProgrammaticOptions(), {
+    reporters: [],
+    cleanTempDir: 'always',
+    logLevel: 'off',
+    fileLogLevel: 'off',
+  });
+});
 
 const detectedRule = {
   id: 'stryker/mutants-detected',

--- a/tests/adapters/stryker.test.ts
+++ b/tests/adapters/stryker.test.ts
@@ -126,6 +126,7 @@ test('a working directory below the Gate root is accepted, and the baseline is r
       'stryker-accepted-mutants-invalid',
       'the inner working directory is accepted, and its own baseline file is the one read',
     );
+    assert.equal(result.why.location?.file, 'project/accepted-mutants.json');
   });
 });
 


### PR DESCRIPTION
## Summary

Battle-tests `@redproof/stryker` against StrykerJS's own Jasmine-runner mutation suite and fixes the two integration defects it exposed.

- Prevents Stryker reporters, console logs, and file logs from competing with Redproof output.
- Makes mutant diagnostics stable and Gate-root-relative instead of exposing deleted proof-copy paths or nested-cwd-relative paths.
- Makes accepted-baseline refusal locations Gate-root-relative.
- Keeps baseline identity matching relative to Stryker's working directory.
- Documents reporter ownership and diagnostic path behavior.

## Claims

1. Redproof JSON and SARIF remain machine-readable while the Stryker Adapter runs.
2. Stryker mutant locations remain usable after a Gate copy is released.
3. Nested `cwd` works consistently for strict mutant Rules, accepted-baseline Rules, and baseline refusals.
4. Producer failures still REFUSE with the thrown Stryker error as diagnostic detail.
5. There is no public API change.

## Expert dogfood evidence

The Adapter was packed locally and run against the latest StrykerJS Jasmine-runner dogfood portfolio:

- 113 mutants inspected.
- Native Stryker status and score semantics matched Redproof.
- One known survivor was accepted by exact identity.
- A survivor-free subsystem proved `mutantsDetected`.
- Stryker's own 100% breaking threshold failed while the Redproof 98% Rule correctly passed, proving exit-state isolation.
- All 8 RED, GREEN, and REFUSE proofs passed.
- JSON output contained no competing Stryker stdout.
- Located evidence resolved to `packages/jasmine-runner/...` and `gates/...`, never a temporary copy.

## Verification

- 652 repository tests passed.
- 50 focused Stryker Adapter and TCK tests passed.
- 5 Gates and 28 Rules passed.
- Full Redproof self-proof portfolio passed.
- Full StrykerJS expert proof portfolio passed: 8/8.
- Typecheck, build, and `git diff --check` passed.