### PR TITLE
Stop ESLint directive notices from refusing a healthy project

### DIFF
--- a/docs/built-in-adapters.md
+++ b/docs/built-in-adapters.md
@@ -262,6 +262,22 @@ A configured ESLint finding becomes a Breach of the corresponding Redproof Rule.
 
 Fatal parsing or execution problems become `REFUSE`, not fake Rule breaches.
 
+An adopted Rule cannot be suppressed in the source. A finding that ESLint
+reports as suppressed by `/* eslint-disable */` still breaches the Redproof
+Rule that adopted it. The ESLint Adapter has no baseline. A Rule you adopt is a
+Rule you keep.
+
+A named target that ESLint declined to inspect becomes `REFUSE` with
+`eslint-incomplete-evidence`, so an ignored file cannot pass as a clean one.
+This covers each path you name in `files`. It does not expand a glob. An
+`ignores` pattern still applies to a glob target, because that is the pattern
+doing what you configured it to do. Name the path in `files` when you need
+Redproof to prove that ESLint read it.
+
+ESLint reports unused `eslint-disable` and `eslint-enable` directives without a
+Rule id. Those describe your configuration, so they are not incomplete
+evidence. Any other ESLint diagnostic without a Rule id is, and it refuses.
+
 ## dependency-cruiser
 
 Package:

--- a/docs/built-in-adapters.md
+++ b/docs/built-in-adapters.md
@@ -264,19 +264,12 @@ Fatal parsing or execution problems become `REFUSE`, not fake Rule breaches.
 
 An adopted Rule cannot be suppressed in the source. A finding that ESLint
 reports as suppressed by `/* eslint-disable */` still breaches the Redproof
-Rule that adopted it. The ESLint Adapter has no baseline. A Rule you adopt is a
-Rule you keep.
+Rule that adopted it. The ESLint Adapter has no baseline.
 
-A named target that ESLint declined to inspect becomes `REFUSE` with
-`eslint-incomplete-evidence`, so an ignored file cannot pass as a clean one.
-This covers each path you name in `files`. It does not expand a glob. An
-`ignores` pattern still applies to a glob target, because that is the pattern
-doing what you configured it to do. Name the path in `files` when you need
-Redproof to prove that ESLint read it.
-
-ESLint reports unused `eslint-disable` and `eslint-enable` directives without a
-Rule id. Those describe your configuration, so they are not incomplete
-evidence. Any other ESLint diagnostic without a Rule id is, and it refuses.
+Name a path in `files` and ESLint must read it. A configured `ignores` pattern
+that excludes that path becomes `REFUSE`, not `PASS`. A glob in `files` keeps
+your `ignores` patterns, so name the path when you need Redproof to prove that
+ESLint read it.
 
 ## dependency-cruiser
 

--- a/packages/eslint/src/model.ts
+++ b/packages/eslint/src/model.ts
@@ -44,12 +44,26 @@ export function fatalEslintDiagnostic(
   return null;
 }
 
+// ESLint reports its own directive bookkeeping without a Rule id. Those
+// messages describe the configuration, not a target ESLint failed to inspect.
+const DIRECTIVE_NOTICES = [
+  'Unused eslint-disable directive',
+  'Unused eslint-enable directive',
+  'Unused inline config',
+];
+
+function directiveNotice(message: EslintMessage): boolean {
+  return DIRECTIVE_NOTICES.some(notice => message.message.startsWith(notice));
+}
+
 export function incompleteEslintDiagnostic(
   root: string,
   results: readonly EslintResult[],
 ): Diagnostic | null {
   for (const result of results) {
-    const incomplete = result.messages.find(message => !message.ruleId && !message.fatal);
+    const incomplete = result.messages.find(
+      message => !message.ruleId && !message.fatal && !directiveNotice(message),
+    );
     if (incomplete) {
       return {
         ...eslintDiagnostic(root, result.filePath, incomplete),

--- a/tests/adapters/eslint.evidence.core.test.ts
+++ b/tests/adapters/eslint.evidence.core.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { incompleteEslintDiagnostic } from '../../packages/eslint/src/model.ts';
+
+const result = (message: string, extra: Record<string, unknown> = {}) => [{
+  filePath: '/repo/src/a.js',
+  messages: [{ ruleId: null, message, ...extra }],
+}];
+
+test('a target ESLint refused to inspect is incomplete evidence', () => {
+  for (const notice of [
+    'File ignored because of a matching ignore pattern. Use "--no-ignore" to disable file ignore settings.',
+    'File ignored because no matching configuration was supplied.',
+    'File ignored because outside of base path.',
+    'File ignored by default. Use "--no-ignore" to override.',
+  ]) {
+    assert.deepEqual(
+      incompleteEslintDiagnostic('/repo', result(notice)),
+      {
+        code: 'eslint-incomplete-evidence',
+        message: notice,
+        location: { file: 'src/a.js', line: null, column: null },
+      },
+      notice,
+    );
+  }
+});
+
+test('ESLint directive bookkeeping is not a target ESLint refused to inspect', () => {
+  for (const notice of [
+    "Unused eslint-disable directive (no problems were reported from 'no-console').",
+    'Unused eslint-disable directive (no problems were reported).',
+    "Unused eslint-enable directive (no matching eslint-disable directives were found for 'no-console').",
+    "Unused inline config ('no-console' is already configured to 'error').",
+  ]) {
+    assert.equal(incompleteEslintDiagnostic('/repo', result(notice)), null, notice);
+  }
+});
+
+test('an unknown Rule-less diagnostic still refuses, so new ESLint output cannot pass silently', () => {
+  assert.equal(
+    incompleteEslintDiagnostic('/repo', result('Something ESLint has not reported before.'))?.code,
+    'eslint-incomplete-evidence',
+  );
+});
+
+test('a fatal parse error stays with the fatal diagnostic, not the incomplete one', () => {
+  assert.equal(
+    incompleteEslintDiagnostic('/repo', result('Parsing error: Unexpected token', { fatal: true })),
+    null,
+  );
+});

--- a/tests/adapters/eslint.test.ts
+++ b/tests/adapters/eslint.test.ts
@@ -171,6 +171,42 @@ test('an explicitly ignored target REFUSES as incomplete evidence', async () => 
   });
 });
 
+test('a stale disable directive does not refuse a healthy project', async () => {
+  await withWorkspace(async root => {
+    await write(root, 'eslint.config.mjs', FLAT_CONFIG);
+    await write(
+      root,
+      'src/stale.js',
+      '/* eslint-disable no-unused-vars */\nexport const value = 1;\n',
+    );
+
+    const result = await run(root, ['src/**/*.js']);
+
+    assert.equal(result.verdict, 'pass', JSON.stringify(result));
+  });
+});
+
+test('a stale disable directive cannot hide a Breach of an adopted Rule', async () => {
+  await withWorkspace(async root => {
+    await write(root, 'eslint.config.mjs', FLAT_CONFIG);
+    await write(
+      root,
+      'src/stale.js',
+      '/* eslint-disable no-unused-vars */\nexport const value = 1;\n',
+    );
+    await write(root, 'src/noisy.js', 'console.log(1);\n');
+
+    const result = await run(root, ['src/**/*.js']);
+
+    assert.equal(result.verdict, 'fail', JSON.stringify(result));
+    if (result.verdict !== 'fail') return;
+    assert.deepEqual(
+      result.breaches.map(item => [item.rule, item.location?.file]),
+      [['eslint/no-console', 'src/noisy.js']],
+    );
+  });
+});
+
 test('an ESLint finding the Gate did not adopt is not a Breach of anything', async () => {
   await withWorkspace(async root => {
     await write(root, 'eslint.config.mjs', `export default [


### PR DESCRIPTION
## Problem

`incompleteEslintDiagnostic` treated every ESLint message without a Rule id as
incomplete evidence and returned REFUSE.

ESLint 9 sets `reportUnusedDisableDirectives` to warn in its default flat
config (`lib/config/default-config.js:62`). No opt-in is needed. One stale
`/* eslint-disable */` comment therefore refuses the whole check.

A real Breach in the same run is lost. The verdict is REFUSE, not FAIL:

```
verdict: refuse
why.code: eslint-incomplete-evidence
why.message: Unused eslint-disable directive (no problems were reported from 'no-unused-vars').
```

`reportUnusedInlineConfigs` produces the same shape.

## Fix

Exclude only ESLint's directive bookkeeping: `Unused eslint-disable directive`,
`Unused eslint-enable directive`, and `Unused inline config`.

The exclusion runs in that direction on purpose. Any other Rule-less
diagnostic still refuses, so an ESLint message this Adapter has not seen before
fails loud instead of passing silently.

The documentation now states three things it did not state before: an adopted
Rule cannot be suppressed in the source, a named target ESLint declined to
inspect refuses, and an `ignores` pattern still applies to a glob target.

## Verification

Red proof. Reverted the predicate to its previous form, kept the tests, rebuilt,
and confirmed the planted text in `dist`:

```
BUILD_EXIT=0
dist/model.js:34: result.messages.find(message => !message.ruleId && !message.fatal)
tests 17 | pass 14 | fail 3
```

The 3 failures were the new tests, including the masked Breach.

Green proof. Restored the predicate and rebuilt:

```
BUILD_EXIT=0
dist/model.js:34: ... && !directiveNotice(message)
tests 17 | pass 17 | fail 0
```

Also run: `npm run typecheck` exit 0, `npm run docs:typecheck` exit 0,
`npm run test:adapters` 240/240 passed, `npm run self:check` 6 Gates and
34 Rules held.