### PR TITLE
Refuse an allowed boundary disabled by allowedSeverity

### DIFF
--- a/packages/dependency-cruiser/README.md
+++ b/packages/dependency-cruiser/README.md
@@ -50,6 +50,11 @@ Every selected dependency-cruiser Rule must also be active. A Rule configured
 with severity `ignore` produces REFUSE, because Redproof cannot honestly claim
 that an architecture boundary holds when dependency-cruiser has disabled it.
 
+The `not-in-allowed` Rule takes its severity from the `allowedSeverity` option
+beside the `allowed` block, not from a severity inside it. `allowedSeverity:
+'ignore'` deletes the whole `allowed` block before the cruise, so that Rule
+produces REFUSE too.
+
 A baseline weakens the Gate on purpose. Keep a RED proof that plants a new
 violation, so the Gate is known to still fail. A baseline that grows with every
 new violation guards nothing and still reports PASS. A baseline file that is not

--- a/packages/dependency-cruiser/src/model.ts
+++ b/packages/dependency-cruiser/src/model.ts
@@ -26,6 +26,7 @@ export type DependencyCruiserConfig = {
   readonly forbidden?: readonly DependencyCruiserRuleDefinition[];
   readonly required?: readonly DependencyCruiserRuleDefinition[];
   readonly allowed?: readonly unknown[];
+  readonly allowedSeverity?: string;
 };
 
 type DependencyCruiserRuleDefinition = {
@@ -41,7 +42,12 @@ export function dependencyCruiserRuleAvailability(
   for (const rule of [...(config.forbidden ?? []), ...(config.required ?? [])]) {
     if (rule.name) configured.set(rule.name, rule.severity);
   }
-  if ((config.allowed?.length ?? 0) > 0) configured.set('not-in-allowed', undefined);
+  // dependency-cruiser carries the severity of the synthetic `not-in-allowed`
+  // rule beside the `allowed` block, not inside it. `ignore` there deletes the
+  // whole block before the cruise, so the boundary is never checked.
+  if ((config.allowed?.length ?? 0) > 0) {
+    configured.set('not-in-allowed', config.allowedSeverity);
+  }
 
   return {
     missing: selected.filter(name => !configured.has(name)),

--- a/tests/adapters/dependency-cruiser.test.ts
+++ b/tests/adapters/dependency-cruiser.test.ts
@@ -181,6 +181,49 @@ test('a Rule disabled in dependency-cruiser REFUSES instead of falsely passing',
   });
 });
 
+test('an allowed boundary disabled by allowedSeverity REFUSES instead of falsely passing', async () => {
+  await withWorkspace(async root => {
+    await writeFakeDependencyCruiser(root, {
+      config: "export default async function extractConfig() { return { allowed: [{ from: {}, to: {} }], allowedSeverity: 'ignore' }; }\n",
+      cruise: "export async function cruise() { throw new Error('cruise must not run'); }\n",
+    });
+
+    const result = await run(adapterFor({ rules: { boundary: 'not-in-allowed' } }), root);
+
+    assert.equal(result.verdict, 'refuse');
+    if (result.verdict !== 'refuse') return;
+    assert.equal(result.why.code, 'dependency-cruiser-rule-inactive');
+    assert.equal(result.why.location?.file, '.dependency-cruiser.mjs');
+    assert.match(result.why.detail ?? '', /not-in-allowed/u);
+    assert.equal(result.scan.inspected, null);
+  });
+});
+
+test('an allowed boundary that is still active is checked, not refused', async () => {
+  await withWorkspace(async root => {
+    await writeFakeDependencyCruiser(root, {
+      config: "export default async function extractConfig() { return { allowed: [{ from: {}, to: {} }] }; }\n",
+      cruise: cruiseReporting(`{
+    totalCruised: 2,
+    violations: [{
+      rule: { name: 'not-in-allowed', severity: 'warn' },
+      from: 'src/a.ts',
+      to: 'src/b.ts',
+    }],
+  }`),
+    });
+
+    const result = await run(adapterFor({ rules: { boundary: 'not-in-allowed' } }), root);
+
+    assert.equal(result.verdict, 'fail', JSON.stringify(result));
+    if (result.verdict !== 'fail') return;
+    assert.deepEqual(
+      result.breaches.map(item => [item.rule, item.location?.file]),
+      [['dependency-cruiser/not-in-allowed', 'src/a.ts']],
+    );
+  });
+});
+
 test('a known-violations baseline is forwarded to dependency-cruiser, and new violations still fail', async () => {
   await withWorkspace(async root => {
     await writeFakeDependencyCruiser(root, {

--- a/tests/adapters/dependency-cruiser.violations.core.test.ts
+++ b/tests/adapters/dependency-cruiser.violations.core.test.ts
@@ -57,6 +57,32 @@ test('rule availability distinguishes active, inactive, and missing configuratio
   );
 });
 
+test('an allowed block disabled by allowedSeverity is inactive, not available', () => {
+  const allowed = [{ from: {}, to: {} }];
+
+  assert.deepEqual(
+    dependencyCruiserRuleAvailability({ allowed, allowedSeverity: 'ignore' }, ['not-in-allowed']),
+    { missing: [], inactive: ['not-in-allowed'] },
+  );
+
+  for (const allowedSeverity of ['error', 'warn', 'info', undefined]) {
+    assert.deepEqual(
+      dependencyCruiserRuleAvailability(
+        { allowed, ...(allowedSeverity ? { allowedSeverity } : {}) },
+        ['not-in-allowed'],
+      ),
+      { missing: [], inactive: [] },
+      `allowedSeverity ${String(allowedSeverity)}`,
+    );
+  }
+
+  assert.deepEqual(
+    dependencyCruiserRuleAvailability({ allowedSeverity: 'ignore' }, ['not-in-allowed']),
+    { missing: ['not-in-allowed'], inactive: [] },
+    'no allowed block at all is missing, not inactive',
+  );
+});
+
 test('each adopted violation becomes a Breach of the Redproof Rule that maps to it', () => {
   const breaches = violationsToBreaches([
     violation('domain-no-infrastructure'),


### PR DESCRIPTION
## Problem

PR #76 made a selected dependency-cruiser Rule with severity `ignore` produce
REFUSE. That closed the hole for `forbidden` and `required` rules. It left the
`allowed` block open.

dependency-cruiser keeps the severity of the synthetic `not-in-allowed` rule in
a separate top-level option, `allowedSeverity`. It sits beside the `allowed`
block, not inside it. `allowedSeverity: 'ignore'` deletes the whole block
before the cruise:

```
node_modules/dependency-cruiser/src/main/rule-set/normalize.mjs:120-125
  if (lRuleSet?.allowed) {
    lRuleSet.allowedSeverity = normalizeSeverity(lRuleSet.allowedSeverity);
    if (lRuleSet.allowedSeverity === "ignore") {
      Reflect.deleteProperty(lRuleSet, "allowed");
```

`dependencyCruiserRuleAvailability` registered `not-in-allowed` with severity
`undefined`, so it could never be reported inactive.

Measured against the real library at 18.2.0, with `src/a.js` importing
`src/b.js` and an `allowed` block that matches nothing:

| config | verdict |
|---|---|
| `allowedSeverity: 'ignore'` | **pass**, inspected 2 |
| `allowedSeverity: 'error'` | fail, breach `dependency-cruiser/not-in-allowed` |

A boundary Gate that reports PASS and can never report anything else is worth
less than no Gate.

## Fix

Read `allowedSeverity` from the extracted configuration and register it as the
severity of `not-in-allowed`. `extractConfig` returns the option, so the value
is available before the cruise starts.

Matching stays exact and lowercase, because dependency-cruiser's own
`normalizeSeverity` tests `/^(?:error|warn|info|ignore)$/` with no case folding.

An absent `allowedSeverity` still means active. dependency-cruiser defaults it
to `warn`.

## Verification

Red proof. Reverted the lookup to the previous `undefined`, rebuilt, and
confirmed the planted text in `dist`:

```
BUILD_EXIT=0
dist/model.js:12: configured.set('not-in-allowed', undefined);
tests 23 | pass 21 | fail 2
```

The 2 failures were the new tests. The neighbouring test "an allowed boundary
that is still active is checked, not refused" stayed green, so the guard does
not over-refuse.

Green proof. Restored the lookup and rebuilt:

```
BUILD_EXIT=0
dist/model.js:12: configured.set('not-in-allowed', config.allowedSeverity);
tests 23 | pass 23 | fail 0
```

Also run: `npm run typecheck` exit 0, `npm run docs:typecheck` exit 0,
`npm run test:adapters` 237/237 passed, `npm run self:check` 6 Gates and
34 Rules held.