### PR TITLE
Derive each published tarball from the package it belongs to

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -153,24 +153,49 @@ jobs:
         run: |
           set -euo pipefail
 
+          PUBLISHED_PACKAGES=()
           for PKG in redproof @redproof/adapter-tck @redproof/eslint @redproof/dependency-cruiser @redproof/stryker @redproof/testing @redproof/knip; do
             if npm view "${PKG}@${VERSION}" version --json >/dev/null 2>&1; then
               echo "Skipping ${PKG}@${VERSION}: already published"
               continue
             fi
 
-            case "$PKG" in
-              redproof) TARBALL="artifacts/redproof-${VERSION}.tgz" ;;
-              @redproof/adapter-tck) TARBALL="artifacts/redproof-adapter-tck-${VERSION}.tgz" ;;
-              @redproof/eslint) TARBALL="artifacts/redproof-eslint-${VERSION}.tgz" ;;
-              @redproof/dependency-cruiser) TARBALL="artifacts/redproof-dependency-cruiser-${VERSION}.tgz" ;;
-              @redproof/stryker) TARBALL="artifacts/redproof-stryker-${VERSION}.tgz" ;;
-              @redproof/knip) TARBALL="artifacts/redproof-knip-${VERSION}.tgz" ;;
-              @redproof/testing) TARBALL="artifacts/redproof-testing-${VERSION}.tgz" ;;
-            esac
+            TARBALL_STEM="${PKG#@}"
+            TARBALL_STEM="${TARBALL_STEM/\//-}"
+            TARBALL="artifacts/${TARBALL_STEM}-${VERSION}.tgz"
 
-            echo "Publishing $TARBALL"
-            npm publish "$TARBALL" --tag "$NPM_TAG" --provenance
+            if [ ! -f "$TARBALL" ]; then
+              echo "::error title=Verified tarball missing::$PKG has no verified tarball at $TARBALL. Package verification and this loop disagree about the release inventory."
+              exit 1
+            fi
+
+            echo "Publishing $PKG from $TARBALL"
+            PUBLISH_STATUS=0
+            npm publish "$TARBALL" --tag "$NPM_TAG" --provenance || PUBLISH_STATUS=$?
+
+            if [ "$PUBLISH_STATUS" -eq 0 ]; then
+              PUBLISHED_PACKAGES+=("$PKG")
+              continue
+            fi
+
+            echo "::error title=Publication stopped::$PKG could not be published at $VERSION."
+            echo
+            if [ "${#PUBLISHED_PACKAGES[@]}" -gt 0 ]; then
+              echo "This release is now partial. Published in this run: ${PUBLISHED_PACKAGES[*]}"
+            else
+              echo "Nothing was published in this run."
+            fi
+            echo
+            echo "A permission failure here usually means this workflow is not yet a"
+            echo "trusted publisher for $PKG. Package existence was checked before"
+            echo "publication began; authorization was not."
+            echo
+            echo "Run this while signed in to npm with package write access and 2FA:"
+            echo "   npm trust github \"$PKG\" --repo schalermthai/redproof --file publish.yml --allow-publish"
+            echo
+            echo "Then re-run this workflow. Already-published package versions are skipped,"
+            echo "so the rerun completes the release rather than repeating it."
+            exit 1
           done
 
       - name: Report a dry run

--- a/gates/support/repository-policy-model.ts
+++ b/gates/support/repository-policy-model.ts
@@ -56,10 +56,6 @@ function escaped(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-function tarballStem(packageName: string): string {
-  return packageName.replace(/^@/, '').replaceAll('/', '-');
-}
-
 function scriptInvokes(
   scripts: Readonly<Record<string, string>>,
   from: string,
@@ -112,11 +108,6 @@ function packageInventory(snapshot: RepositorySnapshot): RepositoryPolicyFinding
         file: '.github/workflows/publish.yml',
         ok: readinessLoop.includes(pkg.name),
         stage: 'npm package readiness check',
-      },
-      {
-        file: '.github/workflows/publish.yml',
-        ok: snapshot.publishWorkflow.includes(`artifacts/${tarballStem(pkg.name)}-\${VERSION}.tgz`),
-        stage: 'verified tarball publish',
       },
       {
         file: '.github/workflows/publish.yml',
@@ -325,6 +316,31 @@ function automationVerification(snapshot: RepositorySnapshot): RepositoryPolicyF
       rule: 'automationVerification',
       code: 'workflow-verification-missing',
       message: '.github/workflows/publish.yml must publish the retained verified tarballs.',
+      file: '.github/workflows/publish.yml',
+    });
+  }
+
+  // A per-package tarball table can pair a package with another package's
+  // tarball. Deriving the name from the loop variable makes that impossible.
+  // Both the readiness guidance and the publish loop must derive it, so one
+  // step alone cannot satisfy this rule for the other.
+  const derivations = snapshot.publishWorkflow
+    .match(/^\s*TARBALL="artifacts\/\$\{TARBALL_STEM\}-\$\{VERSION\}\.tgz"\s*$/gm)
+    ?.length ?? 0;
+  if (derivations < 2) {
+    findings.push({
+      rule: 'automationVerification',
+      code: 'workflow-verification-missing',
+      message: '.github/workflows/publish.yml must derive each tarball name from the package being published.',
+      file: '.github/workflows/publish.yml',
+    });
+  }
+
+  if (/case\s+"\$PKG"\s+in/.test(snapshot.publishWorkflow)) {
+    findings.push({
+      rule: 'automationVerification',
+      code: 'workflow-verification-missing',
+      message: '.github/workflows/publish.yml must not map packages to tarballs by hand.',
       file: '.github/workflows/publish.yml',
     });
   }

--- a/tests/gates/checks.test.ts
+++ b/tests/gates/checks.test.ts
@@ -206,7 +206,7 @@ async function seedRepository(root: string, extra: Readonly<Record<string, strin
     'scripts/set-version.ts': "const dirs = ['packages/redproof'];\n",
     'scripts/verify-package.ts': "const packages = [{ name: 'redproof' }];\n",
     '.github/workflows/ci.yml': ciWorkflow,
-    '.github/workflows/publish.yml': `${publishWorkflow}for READY_PACKAGE in redproof; do\nTARBALL="artifacts/redproof-\${VERSION}.tgz"\nfor PKG in redproof; do\nnpm publish "$TARBALL" --tag "$NPM_TAG"\n`,
+    '.github/workflows/publish.yml': `${publishWorkflow}for READY_PACKAGE in redproof; do\nTARBALL="artifacts/\${TARBALL_STEM}-\${VERSION}.tgz"\nfor PKG in redproof; do\nTARBALL="artifacts/\${TARBALL_STEM}-\${VERSION}.tgz"\nnpm publish "$TARBALL" --tag "$NPM_TAG"\n`,
     'README.md': '[docs](docs/guide.md)\n',
     'docs/guide.md': '# Guide\n',
     ...extra,

--- a/tests/gates/repository-policy.core.test.ts
+++ b/tests/gates/repository-policy.core.test.ts
@@ -53,8 +53,9 @@ function snapshot(overrides: Partial<RepositorySnapshot> = {}): RepositorySnapsh
     publishWorkflow: [
       publishWorkflow,
       'for READY_PACKAGE in redproof; do',
-      'TARBALL="artifacts/redproof-${VERSION}.tgz"',
+      'TARBALL="artifacts/${TARBALL_STEM}-${VERSION}.tgz"',
       'for PKG in redproof; do',
+      'TARBALL="artifacts/${TARBALL_STEM}-${VERSION}.tgz"',
       'npm publish "$TARBALL" --tag "$NPM_TAG"',
     ].join('\n'),
     existingPaths: new Set([
@@ -87,7 +88,6 @@ test('a package missing from any release stage is reported once per stage, again
     ['packageInventory', 'package-missing-from-release-stage', 'scripts/set-version.ts', '@redproof/extra is missing from the version setter.'],
     ['packageInventory', 'package-missing-from-release-stage', 'scripts/verify-package.ts', '@redproof/extra is missing from the package verifier.'],
     ['packageInventory', 'package-missing-from-release-stage', '.github/workflows/publish.yml', '@redproof/extra is missing from the npm package readiness check.'],
-    ['packageInventory', 'package-missing-from-release-stage', '.github/workflows/publish.yml', '@redproof/extra is missing from the verified tarball publish.'],
     ['packageInventory', 'package-missing-from-release-stage', '.github/workflows/publish.yml', '@redproof/extra is missing from the publish loop.'],
     ['publicFiles', 'invalid-package-entrypoint', 'packages/extra/package.json', '@redproof/extra must declare matching runtime and type entrypoints backed by source.'],
   ]);
@@ -104,9 +104,9 @@ test('a second package is accepted once every release stage names it', () => {
     publishWorkflow: [
       publishWorkflow,
       'for READY_PACKAGE in redproof @redproof/extra; do',
-      'TARBALL="artifacts/redproof-${VERSION}.tgz"',
-      'TARBALL="artifacts/redproof-extra-${VERSION}.tgz"',
+      'TARBALL="artifacts/${TARBALL_STEM}-${VERSION}.tgz"',
       'for PKG in redproof @redproof/extra; do',
+      'TARBALL="artifacts/${TARBALL_STEM}-${VERSION}.tgz"',
       'npm publish "$TARBALL" --tag "$NPM_TAG"',
     ].join('\n'),
     existingPaths: new Set([...clean.existingPaths, 'packages/extra/src/index.ts']),
@@ -312,15 +312,27 @@ test('CI and publishing must keep their complete verification portfolios', () =>
   ]);
 });
 
-test('publishing must name the verified tarball for every package', () => {
+test('publishing must derive each tarball from the package, never from a table', () => {
   const clean = snapshot();
-  const findings = evaluateRepositoryPolicy({
-    ...clean,
-    publishWorkflow: clean.publishWorkflow.replace('artifacts/redproof-${VERSION}.tgz', 'artifacts/other-${VERSION}.tgz'),
-  });
 
-  assert.deepEqual(findings.map(item => [item.code, item.message]), [
-    ['package-missing-from-release-stage', 'redproof is missing from the verified tarball publish.'],
+  const noDerivation = evaluateRepositoryPolicy({
+    ...clean,
+    publishWorkflow: clean.publishWorkflow.replace(
+      'TARBALL="artifacts/${TARBALL_STEM}-${VERSION}.tgz"',
+      'TARBALL="artifacts/redproof-${VERSION}.tgz"',
+    ),
+  });
+  assert.equal(noDerivation.length, 1, 'one step deriving the name is not enough');
+  assert.deepEqual(noDerivation.map(item => item.message), [
+    '.github/workflows/publish.yml must derive each tarball name from the package being published.',
+  ]);
+
+  const handWritten = evaluateRepositoryPolicy({
+    ...clean,
+    publishWorkflow: [clean.publishWorkflow, 'case "$PKG" in'].join('\n'),
+  });
+  assert.deepEqual(handWritten.map(item => item.message), [
+    '.github/workflows/publish.yml must not map packages to tarballs by hand.',
   ]);
 });
 


### PR DESCRIPTION
## Problem

The publish loop mapped each package to a tarball with a hand-written `case`
table. Nothing checked that the pairing was right. The repository Gate asked
only that each tarball string and each package name appeared somewhere in the
file.

Swap two labels and the release goes wrong in silence. Measured by extracting
the real loop and running it against a stubbed npm:

```
EXIT=0
6 of 7 packages published
@redproof/eslint: never published
iteration 7: "Skipping @redproof/knip@0.12.0: already published"
```

The already-published skip hides the miss. The release reports success with one
package absent at that version, and npm versions cannot be reused.

A second gap sits beside it. The readiness step proves a package name exists on
npm. It does not prove this workflow is an authorized trusted publisher. A
permission failure therefore lands mid-loop as a bare `E403`, after other
packages are already published, with no guidance.

## Fix

Derive the tarball name from the loop variable, using the same rule the
readiness step already uses. A wrong pairing is then impossible to express.

Refuse to publish when the derived tarball is absent, so package verification
and the publish loop cannot disagree about the inventory in silence.

On a publish failure, report which packages this run already published, name
the likely cause, print the `npm trust` command, and say that a rerun completes
the release rather than repeating it.

The Gate gains two rules. The derivation must appear in both release steps, so
one step cannot satisfy the rule for the other. The `case "$PKG" in` table is
forbidden outright.

I did not add a trusted-publisher pre-check. `npm trust list` needs registry
credentials I cannot exercise here, and an unverifiable step in a release
workflow is the kind of thing this change exists to remove.

## Verification

The real publish step was extracted from the YAML and run against a stubbed
npm. Four paths:

```
A all publishes succeed        EXIT=0, each package paired with its own tarball
B @redproof/knip denied E403   EXIT=1, names the 6 already published, prints npm trust
C rerun after B                EXIT=0, skips the 6, publishes the 7th
D a tarball missing            EXIT=1, "Verified tarball missing", stops before publishing it
```

Red proof 1, the hand-written table reinstated with two labels swapped:

```
exit=1 | Rules 33 held | 1 breached (34)
  must derive each tarball name from the package being published.
  must not map packages to tarballs by hand.
```

Red proof 2, the publish loop stops deriving while the readiness step still
does, and no `case` table is used. This proves the derivation rule can fail on
its own:

```
exit=1 | Rules 33 held | 1 breached (34)
  must derive each tarball name from the package being published.
```

Green, restored both times:

```
exit=0 | Rules 34 held (34)
```

An earlier form of this change wrapped the publish in `if npm publish ...`,
which moved the command off the start of its line and silently broke the
existing "must publish the retained verified tarballs" rule. The red proof
caught it. The command now stays at the start of its line.

Also run: `npm run typecheck` exit 0, `npm test` 711/711 passed,
`npm run self:prove` 48 proofs established and 0 failed, YAML parsed and both
release steps checked with `bash -n`.