### PR TITLE
Forbid publishable Adapter source from importing the test kit

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -91,6 +91,13 @@ module.exports = {
       from: { path: '^packages/[^/]+/src/' },
       to: { path: '^(?:tests|fixtures|scripts|gates)/' },
     },
+    {
+      name: 'production-no-adapter-tck-dependency',
+      severity: 'error',
+      comment: 'The Adapter TCK is test infrastructure. Publishable source must not depend on it, whatever the manifests declare.',
+      from: { path: '^packages/(?!adapter-tck/)[^/]+/src/' },
+      to: { path: '^packages/adapter-tck/' },
+    },
   ],
   options: {
     doNotFollow: { path: 'node_modules' },

--- a/gates/architecture.ts
+++ b/gates/architecture.ts
@@ -21,6 +21,7 @@ const dependencies = dependencyCruiser({
     compositionNoRuntimeOrReporters: 'composition-no-runtime-or-reporters',
     adaptersPublicCoreApiOnly: 'adapters-public-core-api-only',
     productionNoTestFixtureDependencies: 'production-no-test-fixture-dependencies',
+    productionNoAdapterTckDependency: 'production-no-adapter-tck-dependency',
     contextsImportThroughIndex: 'contexts-import-through-index',
     entrypointsImportThroughIndex: 'entrypoints-import-through-index',
   },
@@ -115,6 +116,14 @@ export const proofs = defineProofs(gate, [
     mutate.appendText(
       'packages/redproof/src/domain/rule.ts',
       "\nimport '../../../../fixtures/pass-single/src/parser.ts';\n",
+    ),
+  ),
+  proof.red(
+    rules.productionNoAdapterTckDependency,
+    'keeps the Adapter test kit out of publishable Adapter source',
+    mutate.appendText(
+      'packages/eslint/src/model.ts',
+      "\nimport '../../adapter-tck/src/index.ts';\n",
     ),
   ),
   proof.red(


### PR DESCRIPTION
## Problem

`packages/adapter-tck/README.md` states the rule in words: "The package is test
infrastructure. Adapter production source must not import it; list it only in
`devDependencies`."

Nothing enforced it. Planting a plain import in an Adapter's source:

```ts
// packages/eslint/src/index.ts
import { adapterTckCases } from '@redproof/adapter-tck';
```

```
tsc --noEmit  exit 0
npm run build exit 0
symbol present in packages/eslint/dist/index.js
every Gate held
```

Three things that look like they should catch it do not.

The `packageBoundaries` rule added in #72 reads manifests. A source edge that
no manifest declares is invisible to it.

`.dependency-cruiser.cjs` had two candidate rules and both miss.
`adapters-public-core-api-only` targets `^packages/redproof/src/`.
`production-no-test-fixture-dependencies` targets `^(tests|fixtures|scripts|gates)/`.
Neither names `packages/adapter-tck`.

`npm run verify:package` cannot catch it either. Step 3 installs all seven
tarballs into one consumer, so the undeclared dependency always resolves there.
A real consumer who installs only `@redproof/eslint` gets
`ERR_MODULE_NOT_FOUND`.

## Fix

Add `production-no-adapter-tck-dependency`, from any publishable package source
except the TCK's own, to `packages/adapter-tck/`. Select it in the architecture
Gate and give it a red proof.

The `from` pattern excludes `adapter-tck/src` so the package can still import
itself. It matches `src/` only, so each Adapter's own
`packages/*/test/adapter.tck.test.ts` registration is untouched.

## Verification

Confirmed first that dependency-cruiser resolves the bare specifier to source,
not to the installed copy, so the rule targets the right path:

```
resolved edges from packages/eslint/src/index.ts:
   packages/adapter-tck/src/index.ts
```

Red, using the real bare specifier a person would actually write, rebuilt and
with the planted symbol confirmed in `dist`:

```
BUILD_EXIT=0
planted symbol in dist: 2
exit=1 | Rules 33 held | 2 breached (35)
FAIL gates/architecture.ts > production-no-adapter-tck-dependency
  Dependency packages/eslint/src/index.ts -> packages/adapter-tck/src/index.ts
  violates dependency-cruiser rule production-no-adapter-tck-dependency.
```

Green, restored and rebuilt:

```
Rules 35 held (35)
```

The Gate's own red proof establishes:

```
npm run self:prove -- gates/architecture.ts
established: 16 | failed: 0
  breached dependency-cruiser/production-no-adapter-tck-dependency
```

Also run: `npm run typecheck` exit 0, `npm test` 711/711 passed,
`npm run self:prove` 49 proofs established and 0 failed.

One observation from the red run, unrelated to this change. The second breach
was `test-health/tests-pass`, from a descendant-timeout test that reported
`descendant.pid was never written`. The green run straight afterwards held all
35 Rules, so that test is intermittent under load.